### PR TITLE
Fix syntax error in README.md

### DIFF
--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -76,7 +76,7 @@ include symcrypt in your code
 
 ```rust
 use symcrypt::hash::sha256; 
-use symcrypt::symcrypt_init();
+use symcrypt::symcrypt_init;
 use hex;
 fn main() {
     symcrpyt_init();


### PR DESCRIPTION
Fixing syntax error in the example code