### PR TITLE
Adding RSA, via PCKS1, PSS and OAEP

### DIFF
--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -38,13 +38,19 @@ For more information please see the `INSTALL.md` file on the [`rust-symcrypt`](h
 
 ## Supported APIs
 
-Hashing:
+ Hashing:
+- Md5 ( statefull/stateless )
+- Sha1 ( statefull/stateless )
 - Sha256 ( statefull/stateless )
 - Sha384 ( statefull/stateless )
+- Sha512 ( statefull/stateless )
 
 HMAC:
+- HmacMd5 ( statefull/stateless )
+- HmacSha1 ( statefull/stateless )
 - HmacSha256 ( statefull/stateless )
 - HmacSha384 ( statefull/stateless )
+- HmacSha512 ( statefull/stateless )
 
 GCM:
 - Encryption ( in place )
@@ -56,6 +62,10 @@ ChaCha:
 
 ECDH:
 - ECDH Secret Agreement
+
+**Note**: `Md5` and `Sha1` are considered weak crypto, and are only added for interop purposes.
+To enable either `Md5` or `Sha1` pass the `md5` or `sha1` flag into your `Cargo.toml`
+To enable all weak crypto, you can instead pass `weak-crypto` into your `Cargo.toml` instead.
 
 ## Usage
 There are unit tests attached to each file that show how to use each function. Included is some sample code to do a stateless Sha256 hash. `symcrypt_init()` must be run before any other calls to the underlying symcrypt code.

--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -39,18 +39,18 @@ For more information please see the `INSTALL.md` file on the [`rust-symcrypt`](h
 ## Supported APIs
 
  Hashing:
-- Md5 ( statefull/stateless )
-- Sha1 ( statefull/stateless )
-- Sha256 ( statefull/stateless )
-- Sha384 ( statefull/stateless )
-- Sha512 ( statefull/stateless )
+- Md5 ( stateful/stateless )
+- Sha1 ( stateful/stateless )
+- Sha256 ( stateful/stateless )
+- Sha384 ( stateful/stateless )
+- Sha512 ( stateful/stateless )
 
 HMAC:
-- HmacMd5 ( statefull/stateless )
-- HmacSha1 ( statefull/stateless )
-- HmacSha256 ( statefull/stateless )
-- HmacSha384 ( statefull/stateless )
-- HmacSha512 ( statefull/stateless )
+- HmacMd5 ( stateful/stateless )
+- HmacSha1 ( stateful/stateless )
+- HmacSha256 ( stateful/stateless )
+- HmacSha384 ( stateful/stateless )
+- HmacSha512 ( stateful/stateless )
 
 GCM:
 - Encryption ( in place )

--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -44,6 +44,9 @@ Hashing:
 - Sha256 ( stateful/stateless )
 - Sha384 ( stateful/stateless )
 - Sha512 ( stateful/stateless )
+- Sha3_256 ( stateful/stateless )
+- Sha3_384 ( stateful/stateless )
+- Sha3_512 ( stateful/stateless )
 
 HMAC:
 - HmacMd5 ( stateful/stateless )

--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -38,7 +38,7 @@ For more information please see the `INSTALL.md` file on the [`rust-symcrypt`](h
 
 ## Supported APIs
 
- Hashing:
+Hashing:
 - Md5 ( stateful/stateless )
 - Sha1 ( stateful/stateless )
 - Sha256 ( stateful/stateless )
@@ -62,6 +62,11 @@ ChaCha:
 
 ECDH:
 - ECDH Secret Agreement
+
+RSA: 
+- PKCS1 ( Sign, Verify, Encrypt, Decrypt )
+- PSS ( Sign, Verify )
+- OAEP ( Encrypt, Decrypt )
 
 **Note**: `Md5` and `Sha1` are considered weak crypto, and are only added for interop purposes.
 To enable either `Md5` or `Sha1` pass the `md5` or `sha1` flag into your `Cargo.toml`

--- a/rust-symcrypt/src/eckey.rs
+++ b/rust-symcrypt/src/eckey.rs
@@ -5,6 +5,7 @@
 use crate::{errors::SymCryptError, symcrypt_init};
 use lazy_static::lazy_static;
 use symcrypt_sys;
+use crate::NumberFormat;
 
 /// [`CurveType`] provides an enum of the curve types that can be used when creating a key(s)
 /// via `ecdh::EcDh::new()`. The current curve types supported is `NistP256`, `NistP384`, and `Curve25519`.
@@ -157,10 +158,10 @@ pub(crate) fn convert_curve(curve: CurveType) -> symcrypt_sys::PCSYMCRYPT_ECURVE
 pub(crate) fn get_num_format(curve_type: CurveType) -> i32 {
     let num_format = match curve_type {
         CurveType::Curve25519 => {
-            symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_LSB_FIRST
+            NumberFormat::LSB.to_num_format()
         }
         CurveType::NistP256 | CurveType::NistP384 => {
-            return symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_MSB_FIRST
+            NumberFormat::MSB.to_num_format()
         }
     };
     num_format

--- a/rust-symcrypt/src/eckey.rs
+++ b/rust-symcrypt/src/eckey.rs
@@ -157,8 +157,8 @@ pub(crate) fn convert_curve(curve: CurveType) -> symcrypt_sys::PCSYMCRYPT_ECURVE
 // get_num_format returns the correct number format needed for TLS interop since 25519 spec defines the use of Little Endian.
 pub(crate) fn get_num_format(curve_type: CurveType) -> i32 {
     let num_format = match curve_type {
-        CurveType::Curve25519 => NumberFormat::LSB.to_num_format(),
-        CurveType::NistP256 | CurveType::NistP384 => NumberFormat::MSB.to_num_format(),
+        CurveType::Curve25519 => NumberFormat::LSB.to_symcrypt_format(),
+        CurveType::NistP256 | CurveType::NistP384 => NumberFormat::MSB.to_symcrypt_format(),
     };
     num_format
 }

--- a/rust-symcrypt/src/eckey.rs
+++ b/rust-symcrypt/src/eckey.rs
@@ -2,10 +2,10 @@
 //!
 //! The [`CurveType`] enum provides an enumeration of supported curves that can be used in
 //! elliptical curve operations. Currently the only supported curves are `NistP256`, `NistP384` and `Curve25519`
+use crate::NumberFormat;
 use crate::{errors::SymCryptError, symcrypt_init};
 use lazy_static::lazy_static;
 use symcrypt_sys;
-use crate::NumberFormat;
 
 /// [`CurveType`] provides an enum of the curve types that can be used when creating a key(s)
 /// via `ecdh::EcDh::new()`. The current curve types supported is `NistP256`, `NistP384`, and `Curve25519`.
@@ -18,7 +18,7 @@ pub enum CurveType {
 
 // EcKey is a wrapper around symcrypt_sys::PSYMCRYPT_ECKEY.
 pub(crate) struct EcKey {
-    // Allocation for EcKey is handled by SymCrypt via SymCryptEcKeyAllocate, and is subsequently stored on the stack;
+    // Allocation for EcKey is handled by SymCrypt via SymCryptEcKeyAllocate, and is subsequently stored on the heap;
     // therefore pointer will not move and Box<> is not needed.
     inner: symcrypt_sys::PSYMCRYPT_ECKEY,
     curve: &'static EcCurve,
@@ -157,12 +157,8 @@ pub(crate) fn convert_curve(curve: CurveType) -> symcrypt_sys::PCSYMCRYPT_ECURVE
 // get_num_format returns the correct number format needed for TLS interop since 25519 spec defines the use of Little Endian.
 pub(crate) fn get_num_format(curve_type: CurveType) -> i32 {
     let num_format = match curve_type {
-        CurveType::Curve25519 => {
-            NumberFormat::LSB.to_num_format()
-        }
-        CurveType::NistP256 | CurveType::NistP384 => {
-            NumberFormat::MSB.to_num_format()
-        }
+        CurveType::Curve25519 => NumberFormat::LSB.to_num_format(),
+        CurveType::NistP256 | CurveType::NistP384 => NumberFormat::MSB.to_num_format(),
     };
     num_format
 }

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -943,6 +943,7 @@ mod test {
         hash_state.append(&data_2);
 
         let result = hash_state.result();
+        assert_eq!(hash_state.get_hash_algorithm().get_result_size(), result.as_ref().len());
         assert_eq!(hex::encode(result), expected);
     }
 

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -146,6 +146,22 @@ impl HashAlgorithm {
             }
         }
     }
+
+    /// Returns the result size as a `usize`. This is the size of the hash result in bytes.
+    pub fn get_result_size(&self) -> usize {
+        match self {
+            #[cfg(feature = "md5")]
+            HashAlgorithm::Md5 => MD5_RESULT_SIZE,
+            #[cfg(feature = "sha1")]
+            HashAlgorithm::Sha1 => SHA1_RESULT_SIZE,
+            HashAlgorithm::Sha256 => SHA256_RESULT_SIZE,
+            HashAlgorithm::Sha384 => SHA384_RESULT_SIZE,
+            HashAlgorithm::Sha512 => SHA512_RESULT_SIZE,
+            HashAlgorithm::Sha3_256 => SHA3_256_RESULT_SIZE,
+            HashAlgorithm::Sha3_384 => SHA3_384_RESULT_SIZE,
+            HashAlgorithm::Sha3_512 => SHA3_512_RESULT_SIZE,
+        }
+    }
 }
 
 /// Generic trait for stateful hashing
@@ -156,12 +172,16 @@ impl HashAlgorithm {
 ///
 /// `result()` returns the result of the hash. The state is wiped and re-initialized and ready for re-use; you
 /// do not need to re-run a `new()` call. This call cannot fail.
+/// 
+/// `get_hash_algorithm()` returns the associated [`HashAlgorithm`] used by the state.
 pub trait HashState: Clone {
     type Result;
 
     fn append(&mut self, data: &[u8]);
 
     fn result(&mut self) -> Self::Result;
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm;
 }
 
 /// [`Md5State`] is a struct that represents a stateful md5 hash and implements the [`HashState`] trait.
@@ -206,6 +226,10 @@ impl HashState for Md5State {
             symcrypt_sys::SymCryptMd5Result(&mut *self.0, result.as_mut_ptr());
         }
         result
+    }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Md5
     }
 }
 
@@ -297,6 +321,10 @@ impl HashState for Sha1State {
         }
         result
     }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha1
+    }
 }
 
 #[cfg(feature = "sha1")]
@@ -384,6 +412,10 @@ impl HashState for Sha256State {
         }
         result
     }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha256
+    }
 }
 
 impl Clone for Sha256State {
@@ -467,6 +499,10 @@ impl HashState for Sha384State {
             symcrypt_sys::SymCryptSha384Result(&mut *self.0, result.as_mut_ptr());
         }
         result
+    }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha384
     }
 }
 
@@ -552,6 +588,10 @@ impl HashState for Sha512State {
         }
         result
     }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha512
+    }
 }
 
 impl Clone for Sha512State {
@@ -636,6 +676,10 @@ impl HashState for Sha3_256State {
             symcrypt_sys::SymCryptSha3_256Result(&mut *self.0, result.as_mut_ptr());
         }
         result
+    }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha3_256
     }
 }
 
@@ -723,6 +767,10 @@ impl HashState for Sha3_384State {
         }
         result
     }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha3_384
+    }
 }
 
 impl Clone for Sha3_384State {
@@ -808,6 +856,10 @@ impl HashState for Sha3_512State {
             symcrypt_sys::SymCryptSha3_512Result(&mut *self.0, result.as_mut_ptr());
         }
         result
+    }
+
+    fn get_hash_algorithm(&self) -> HashAlgorithm {
+        HashAlgorithm::Sha3_512
     }
 }
 

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -86,6 +86,59 @@ pub const SHA384_RESULT_SIZE: usize = symcrypt_sys::SYMCRYPT_SHA384_RESULT_SIZE 
 /// 64
 pub const SHA512_RESULT_SIZE: usize = symcrypt_sys::SYMCRYPT_SHA512_RESULT_SIZE as usize;
 
+/// Hashing Algorithms that are supported by SymCrypt
+#[derive(Copy, Clone)]
+pub enum HashAlgorithm {
+    #[cfg(feature = "md5")]
+    Md5,
+    #[cfg(feature = "sha1")]
+    Sha1,
+    Sha256,
+    Sha384,
+    Sha512,
+    Sha3_256,
+    Sha3_384,
+    Sha3_512,
+}
+
+impl HashAlgorithm {
+    // Returns the symcrypt_sys::_SYMCRYPT_OID for calling underlying SymCrypt functions, hidden from the user.
+    pub(crate) fn to_oid_list(&self) -> &[symcrypt_sys::_SYMCRYPT_OID] {
+        unsafe {
+            match self {
+                #[cfg(feature = "md5")]
+                HashAlgorithm::Md5 => &symcrypt_sys::SymCryptMd5OidList,
+                #[cfg(feature = "sha1")]
+                HashAlgorithm::Sha1 => &symcrypt_sys::SymCryptSha1OidList,
+                HashAlgorithm::Sha256 => &symcrypt_sys::SymCryptSha256OidList,
+                HashAlgorithm::Sha384 => &symcrypt_sys::SymCryptSha384OidList,
+                HashAlgorithm::Sha512 => &symcrypt_sys::SymCryptSha512OidList,
+                HashAlgorithm::Sha3_256 => &symcrypt_sys::SymCryptSha3_256OidList,
+                HashAlgorithm::Sha3_384 => &symcrypt_sys::SymCryptSha3_384OidList,
+                HashAlgorithm::Sha3_512 => &symcrypt_sys::SymCryptSha3_512OidList,
+            }
+        }
+    }
+    
+    /// Returns the symcrypt_sys::PCSYMCRYPT_HASH for calling underlying SymCrypt functions, hidden from the user.
+    pub(crate) fn to_symcrypt_hash(&self) -> symcrypt_sys::PCSYMCRYPT_HASH {
+        unsafe {
+            match self {
+                #[cfg(feature = "md5")]
+                HashAlgorithm::Md5 => symcrypt_sys::SymCryptMd5Algorithm,
+                #[cfg(feature = "sha1")]
+                HashAlgorithm::Sha1 => symcrypt_sys::SymCryptSha1Algorithm,
+                HashAlgorithm::Sha256 => symcrypt_sys::SymCryptSha256Algorithm,
+                HashAlgorithm::Sha384 => symcrypt_sys::SymCryptSha384Algorithm,
+                HashAlgorithm::Sha512 => symcrypt_sys::SymCryptSha512Algorithm,
+                HashAlgorithm::Sha3_256 => symcrypt_sys::SymCryptSha3_256Algorithm,
+                HashAlgorithm::Sha3_384 => symcrypt_sys::SymCryptSha3_384Algorithm,
+                HashAlgorithm::Sha3_512 => symcrypt_sys::SymCryptSha3_512Algorithm,
+            }
+        }
+    }
+}
+
 /// Generic trait for stateful hashing
 ///
 /// `Result` will be dependent on the which [`HashState`] you use.

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -128,7 +128,7 @@ impl HashAlgorithm {
             }
         }
     }
-    
+
     /// Returns the symcrypt_sys::PCSYMCRYPT_HASH for calling underlying SymCrypt functions, hidden from the user.
     pub(crate) fn to_symcrypt_hash(&self) -> symcrypt_sys::PCSYMCRYPT_HASH {
         unsafe {
@@ -605,7 +605,8 @@ pub struct Sha3_256State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_256_STATE>>);
 
 impl Sha3_256State {
     pub fn new() -> Self {
-        let mut instance = Sha3_256State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default()));
+        let mut instance =
+            Sha3_256State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default()));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_256Init(&mut *instance.0);
@@ -640,7 +641,8 @@ impl HashState for Sha3_256State {
 
 impl Clone for Sha3_256State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha3_256State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default()));
+        let mut new_state =
+            Sha3_256State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default()));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_256StateCopy(&*self.0, &mut *new_state.0);
@@ -689,7 +691,8 @@ pub struct Sha3_384State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_384_STATE>>);
 
 impl Sha3_384State {
     pub fn new() -> Self {
-        let mut instance = Sha3_384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default()));
+        let mut instance =
+            Sha3_384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default()));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_384Init(&mut *instance.0);
@@ -724,7 +727,8 @@ impl HashState for Sha3_384State {
 
 impl Clone for Sha3_384State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha3_384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default()));
+        let mut new_state =
+            Sha3_384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default()));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_384StateCopy(&*self.0, &mut *new_state.0);
@@ -773,7 +777,8 @@ pub struct Sha3_512State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_512_STATE>>);
 
 impl Sha3_512State {
     pub fn new() -> Self {
-        let mut instance = Sha3_512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default()));
+        let mut instance =
+            Sha3_512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default()));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_512Init(&mut *instance.0);
@@ -808,7 +813,8 @@ impl HashState for Sha3_512State {
 
 impl Clone for Sha3_512State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha3_512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default()));
+        let mut new_state =
+            Sha3_512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default()));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_512StateCopy(&*self.0, &mut *new_state.0);
@@ -936,28 +942,28 @@ mod test {
     }
 
     #[test]
-    fn test_stateless_sha3_256_hash() { 
+    fn test_stateless_sha3_256_hash() {
         let data = hex::decode("").unwrap();
         let expected: &str = "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a";
         let result = sha3_256(&data);
         assert_eq!(hex::encode(result), expected);
     }
-    
+
     #[test]
-    fn test_stateless_sha3_384_hash() { 
+    fn test_stateless_sha3_384_hash() {
         let data = hex::decode("").unwrap();
         let expected: &str = "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004";
         let result = sha3_384(&data);
         assert_eq!(hex::encode(result), expected);
-    }   
+    }
 
     #[test]
-    fn test_stateless_sha3_512_hash() { 
+    fn test_stateless_sha3_512_hash() {
         let data = hex::decode("").unwrap();
         let expected: &str = "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26";
         let result = sha3_512(&data);
         assert_eq!(hex::encode(result), expected);
-    }   
+    }
 
     #[cfg(feature = "md5")]
     #[test]
@@ -1074,7 +1080,6 @@ mod test {
         let data = hex::decode("fc7b8cda").unwrap();
         test_generic_state_clone(Sha3_512State::new(), &data);
     }
-
 
     #[cfg(feature = "md5")]
     #[test]

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -172,7 +172,7 @@ impl HashAlgorithm {
 ///
 /// `result()` returns the result of the hash. The state is wiped and re-initialized and ready for re-use; you
 /// do not need to re-run a `new()` call. This call cannot fail.
-/// 
+///
 /// `get_hash_algorithm()` returns the associated [`HashAlgorithm`] used by the state.
 pub trait HashState: Clone {
     type Result;
@@ -943,7 +943,10 @@ mod test {
         hash_state.append(&data_2);
 
         let result = hash_state.result();
-        assert_eq!(hash_state.get_hash_algorithm().get_result_size(), result.as_ref().len());
+        assert_eq!(
+            hash_state.get_hash_algorithm().get_result_size(),
+            result.as_ref().len()
+        );
         assert_eq!(hex::encode(result), expected);
     }
 

--- a/rust-symcrypt/src/hmac.rs
+++ b/rust-symcrypt/src/hmac.rs
@@ -842,7 +842,6 @@ struct HmacSha512Inner {
     expanded_key: Pin<Arc<HmacSha512ExpandedKey>>,
 }
 
-
 impl HmacSha512State {
     /// `new()` takes in a reference to a key and can return a `SymCryptError` that is propagated back to the caller.
     pub fn new(key: &[u8]) -> Result<Self, SymCryptError> {

--- a/rust-symcrypt/src/lib.rs
+++ b/rust-symcrypt/src/lib.rs
@@ -20,6 +20,9 @@
 //! - Sha256 ( stateful/stateless )
 //! - Sha384 ( stateful/stateless )
 //! - Sha512 ( stateful/stateless )
+//! - Sha3_256 ( stateful/stateless )
+//! - Sha3_384 ( stateful/stateless )
+//! - Sha3_512 ( stateful/stateless )
 //!
 //! HMAC:
 //! - HmacMd5 ( stateful/stateless )

--- a/rust-symcrypt/src/lib.rs
+++ b/rust-symcrypt/src/lib.rs
@@ -106,16 +106,26 @@ pub fn symcrypt_random(buff: &mut [u8]) {
     }
 }
 
+/// `NumberFormat` is an enum that contains a friendly representation of endianess
+///
+/// `LSB`: Bytes are ordered from the least significant to the most significant, commonly referred to as "little-endian".
+///
+/// `MSB`: Bytes are ordered from the most significant to the least significant, commonly referred to as "big-endian".
 pub enum NumberFormat {
     LSB,
     MSB,
 }
 
 impl NumberFormat {
-    fn to_num_format(&self) -> symcrypt_sys::SYMCRYPT_NUMBER_FORMAT {        
+    /// Converts `NumberFormat` to the corresponding `SYMCRYPT_NUMBER_FORMAT`
+    fn to_num_format(&self) -> symcrypt_sys::SYMCRYPT_NUMBER_FORMAT {
         match self {
-            NumberFormat::LSB => symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_LSB_FIRST,
-            NumberFormat::MSB => symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
+            NumberFormat::LSB => {
+                symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_LSB_FIRST
+            }
+            NumberFormat::MSB => {
+                symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_MSB_FIRST
+            }
         }
     }
 }

--- a/rust-symcrypt/src/lib.rs
+++ b/rust-symcrypt/src/lib.rs
@@ -15,18 +15,18 @@
 //! ## Supported APIs
 //!
 //! Hashing:
-//! - Md5 ( statefull/stateless )
-//! - Sha1 ( statefull/stateless )
-//! - Sha256 ( statefull/stateless )
-//! - Sha384 ( statefull/stateless )
-//! - Sha512 ( statefull/stateless )
+//! - Md5 ( stateful/stateless )
+//! - Sha1 ( stateful/stateless )
+//! - Sha256 ( stateful/stateless )
+//! - Sha384 ( stateful/stateless )
+//! - Sha512 ( stateful/stateless )
 //!
 //! HMAC:
-//! - HmacMd5 ( statefull/stateless )
-//! - HmacSha1 ( statefull/stateless )
-//! - HmacSha256 ( statefull/stateless )
-//! - HmacSha384 ( statefull/stateless )
-//! - HmacSha512 ( statefull/stateless )
+//! - HmacMd5 ( stateful/stateless )
+//! - HmacSha1 ( stateful/stateless )
+//! - HmacSha256 ( stateful/stateless )
+//! - HmacSha384 ( stateful/stateless )
+//! - HmacSha512 ( stateful/stateless )
 //!
 //! GCM:
 //! - Encryption ( in place )
@@ -81,6 +81,7 @@ pub mod gcm;
 pub mod hash;
 pub mod hmac;
 pub mod rsa;
+// pub mod pkcs1;
 
 /// `symcrypt_init()` must be called before any other function in the library. `symcrypt_init()` can be called multiple times,
 ///  all subsequent calls will be no-ops
@@ -118,7 +119,7 @@ pub enum NumberFormat {
 
 impl NumberFormat {
     /// Converts `NumberFormat` to the corresponding `SYMCRYPT_NUMBER_FORMAT`
-    fn to_num_format(&self) -> symcrypt_sys::SYMCRYPT_NUMBER_FORMAT {
+    fn to_symcrypt_format(&self) -> symcrypt_sys::SYMCRYPT_NUMBER_FORMAT {
         match self {
             NumberFormat::LSB => {
                 symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_LSB_FIRST

--- a/rust-symcrypt/src/lib.rs
+++ b/rust-symcrypt/src/lib.rs
@@ -39,6 +39,11 @@
 //! ECDH:
 //! - ECDH Secret Agreement
 //!
+//! RSA:
+//! - PKCS1 ( Sign, Verify, Encrypt, Decrypt )
+//! - PSS ( Sign, Verify )
+//! - OAEP ( Encrypt, Decrypt )
+//!
 //! **Note**: `Md5` and `Sha1` are considered weak crypto, and are only added for interop purposes.
 //! To enable either `Md5` or `Sha1` pass the `md5` or `sha1` flag into your `Cargo.toml`
 //! To enable all weak crypto, you can instead pass `weak-crypto` into your `Cargo.toml` instead.
@@ -81,7 +86,6 @@ pub mod gcm;
 pub mod hash;
 pub mod hmac;
 pub mod rsa;
-// pub mod pkcs1;
 
 /// `symcrypt_init()` must be called before any other function in the library. `symcrypt_init()` can be called multiple times,
 ///  all subsequent calls will be no-ops

--- a/rust-symcrypt/src/lib.rs
+++ b/rust-symcrypt/src/lib.rs
@@ -15,12 +15,18 @@
 //! ## Supported APIs
 //!
 //! Hashing:
+//! - Md5 ( statefull/stateless )
+//! - Sha1 ( statefull/stateless )
 //! - Sha256 ( statefull/stateless )
 //! - Sha384 ( statefull/stateless )
+//! - Sha512 ( statefull/stateless )
 //!
 //! HMAC:
+//! - HmacMd5 ( statefull/stateless )
+//! - HmacSha1 ( statefull/stateless )
 //! - HmacSha256 ( statefull/stateless )
 //! - HmacSha384 ( statefull/stateless )
+//! - HmacSha512 ( statefull/stateless )
 //!
 //! GCM:
 //! - Encryption ( in place )
@@ -32,6 +38,10 @@
 //!
 //! ECDH:
 //! - ECDH Secret Agreement
+//!
+//! **Note**: `Md5` and `Sha1` are considered weak crypto, and are only added for interop purposes.
+//! To enable either `Md5` or `Sha1` pass the `md5` or `sha1` flag into your `Cargo.toml`
+//! To enable all weak crypto, you can instead pass `weak-crypto` into your `Cargo.toml` instead.
 //!
 //! ## Usage
 //! There are unit tests attached to each file that show how to use each function. Included is some sample code to do a stateless Sha256 hash. `symcrypt_init()` must be run before any other calls to the underlying symcrypt code.
@@ -70,6 +80,7 @@ pub mod errors;
 pub mod gcm;
 pub mod hash;
 pub mod hmac;
+pub mod rsa;
 
 /// `symcrypt_init()` must be called before any other function in the library. `symcrypt_init()` can be called multiple times,
 ///  all subsequent calls will be no-ops
@@ -92,6 +103,20 @@ pub fn symcrypt_random(buff: &mut [u8]) {
     unsafe {
         // SAFETY: FFI calls
         symcrypt_sys::SymCryptRandom(buff.as_mut_ptr(), buff.len() as u64);
+    }
+}
+
+pub enum NumberFormat {
+    LSB,
+    MSB,
+}
+
+impl NumberFormat {
+    fn to_num_format(&self) -> symcrypt_sys::SYMCRYPT_NUMBER_FORMAT {        
+        match self {
+            NumberFormat::LSB => symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_LSB_FIRST,
+            NumberFormat::MSB => symcrypt_sys::_SYMCRYPT_NUMBER_FORMAT_SYMCRYPT_NUMBER_FORMAT_MSB_FIRST,
+        }
     }
 }
 

--- a/rust-symcrypt/src/rsa.rs
+++ b/rust-symcrypt/src/rsa.rs
@@ -469,15 +469,8 @@ mod test {
         assert_eq!(key_pair.key_usage(), RsaKeyUsage::Sign);
 
         let blob = key_pair.export_key_pair_blob().unwrap();
-
-
-        let n_bits_mod = blob.modulus.len() *8;
-
-
-        let new_key_pair = RsaKeyPair::set_key_pair(n_bits_mod as u32, &blob.modulus, &blob.pub_exp, &blob.p, &blob.q, key_pair.key_usage).unwrap();
-
+        let new_key_pair = RsaKeyPair::set_key_pair( &blob.modulus, &blob.pub_exp, &blob.p, &blob.q, key_pair.key_usage).unwrap();
         let blob_2 = new_key_pair.export_key_pair_blob().unwrap();
-
         assert_eq!(blob_2.crt_coefficient, blob.crt_coefficient);
     }
 
@@ -559,7 +552,7 @@ mod test {
             17, 124, 191, 60, 163, 218, 149, 209, 207, 181,
         ];
         let pub_exp: u64 = 65537;
-        let result = RsaPublicKey::set_public_key(2048, &modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
+        let result = RsaPublicKey::set_public_key(&modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
 
         assert!(result.is_ok());
         let pub_key = result.unwrap();

--- a/rust-symcrypt/src/rsa.rs
+++ b/rust-symcrypt/src/rsa.rs
@@ -1,0 +1,479 @@
+//! Rsa functions. For further documentation please refer to symcrypt.h
+//! TODO rest of the documentation 
+use crate::errors::SymCryptError;
+use crate::NumberFormat;
+use std::fmt;
+use std::{pin::Pin, ptr};
+
+const MAX_NUMBER_OF_PUBLIC_EXPONENTS: symcrypt_sys::UINT32 = 1;
+const DEFAULT_PUBLIC_EXPONENT: u64 = 65537;
+
+/// Key State for Rsa Keys.
+///
+/// [`RsaKeyPair`] can store either a public key only, or a private and public key. This information will be stored on the `key_mode` field and can be accessed by [`RsaKeyPair::get_key_mode()`].
+pub struct RsaKeyPair {
+    inner: Pin<Box<symcrypt_sys::PSYMCRYPT_RSAKEY>>, // Pin<box<>> to not move the underlying data.
+    key_mode: RsaKeyMode, // Indicates if the key will contain a private/public keypair, or only a public key.
+    key_usage: RsaKeyUsage,
+    num_p_exp: u32, // !REVIEW this is not needed since the public exponent will always be one
+}
+
+impl fmt::Debug for RsaKeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RsaKey")
+            .field(
+                "inner",
+                &format_args!("{:p}", *self.inner.as_ref().get_ref()),
+            )
+            .field("key_mode", &self.key_mode)
+            .field("key_usage", &self.key_usage)
+            .finish()
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+/// `RsaKeyMode` will indicate if this [`RsaKeyPair`] has [`RsaKeyMode::PublicOnly`] key or a [`RsaKeyMode::KeyPair`].
+pub enum RsaKeyMode {
+    PublicOnly,
+    KeyPair,
+}
+
+impl RsaKeyMode {
+    fn to_u32(&self) -> symcrypt_sys::UINT32 {
+        match self {
+            RsaKeyMode::PublicOnly => 0 as symcrypt_sys::UINT32,
+            RsaKeyMode::KeyPair => 2 as symcrypt_sys::UINT32,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+/// `RsaKeyUsage` will indicate if this [`RsaKeyPair`] will be used for [`RsaKeyUsage::Sign`] or [`RsaKeyUsage::Encrypt`].
+pub enum RsaKeyUsage {
+    Sign,
+    Encrypt,
+}
+
+// !REVIEW: Based on the discussions i've had with Phil, and Sam offline, im not sure if we want to include the minimal validation or no fips flags as the purpose of this
+// code will be to eventually be fips certified. We can include if the group thinks otherwise though. 
+
+// #define SYMCRYPT_FLAG_KEY_NO_FIPS               (0x100)
+// #define SYMCRYPT_FLAG_KEY_MINIMAL_VALIDATION    (0x200)
+// #define SYMCRYPT_FLAG_RSAKEY_SIGN       (0x1000)
+// #define SYMCRYPT_FLAG_RSAKEY_ENCRYPT    (0x2000)
+impl RsaKeyUsage {
+    pub fn to_flag(&self) -> symcrypt_sys::UINT32 {
+        // making public so callers can access underlying flag
+        match self {
+            RsaKeyUsage::Sign => symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN,
+            RsaKeyUsage::Encrypt => symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT,
+        }
+    }
+}
+
+pub enum PrimeIndex {
+    First,
+    Second,
+}
+
+impl PrimeIndex {
+    pub fn to_u32(self) -> u32 {
+        match self {
+            PrimeIndex::First => 0,
+            PrimeIndex::Second => 1,
+        }
+    }
+}
+
+/// !REVIEW: I've tried to closely follow SymCrypts API calls and semantics making some simplifications, but I think we have the opperuntiy to simplify further if we chose.
+/// My questions / Suggestions
+/// 1. We've introduced the idea of the RsaKeyPair state, which can hold a lot of data, and makes a lot of the calls to the underlying SymCrypt code redundant. most of the accessors no longer
+/// need to call SymCrypt since the same data is stored on the state.
+/// 2. The idea of new() then generate_key() / generate_set_public_only() / set_key_pair() is a bit convoluted IMO, we can squash these together to something like: 
+/// new_random(), and  new_set_public() and new_set_key_pair().
+/// 3. Many of the functions ( get, set etc ) take in a NumberFormat that has to match the other specified arguments, is this something we want to store on the state?
+/// 4. Another thought is to leave as is, and write a crate on top of this one, called something like symcrypt_rsa_parse, which will be a friendlier interface on top of the RSA code we have right now
+/// It would have convenience functions like rsa_from_pkcs8, rsa_from_der, rsa_from_asn1 etc. ( this could be part of the intern project as well.)
+/// 5. with how many steps / options there is for generating a key, we can maybe do a builder pattern, this would be similar to how it is on NCrypt / BCrypt where they have 
+/// RsaKey functions and the RsaKey.finalize() at the end.
+/// ex:
+///         builder = RsaKeyBuilder::new()
+///             .key_mode(RsaKeyMode::KeyPair)
+///             .key_usage(RsaKeyUsage::Sign)
+///             .generate_key()
+
+
+/// Impl for the RsaKeyPair
+impl RsaKeyPair {
+    /// `new()` allocates a the space needed for an `RsaKeyPair`.
+    /// To fill data, you must call one of [`RsaKeyPair::generate_key()`], [`RsaKeyPair::set_public_only()`] or [`RsaKeyPair::set_key_pair()`].
+    /// 
+    /// `n_bits_mod` represents the desired bit length of the Rsa Key.
+    /// 
+    /// `key_mode` will determine if this key will be allocated for a [`RsaKeyMode::PublicOnly`] or [`RsaKeyMode::KeyPair`] 
+    /// 
+    /// `key_usage` will indicate if this key will be used for [`RsaKeyUsage::Sign`] or [`RsaKeyUsage::Encrypt`]
+    pub fn new(n_bits_mod: u32, key_mode: RsaKeyMode, key_usage: RsaKeyUsage) -> Self {
+        let rsa_params = symcrypt_sys::SYMCRYPT_RSA_PARAMS {
+            version: 1 as symcrypt_sys::UINT32, // No other version aside from version 1 is specified
+            nBitsOfModulus: n_bits_mod as symcrypt_sys::UINT32,
+            nPrimes: key_mode.to_u32(), //  Value must be 0 or 2, if only a public key is being generated, you can pass 0 for n_primes
+            nPubExp: MAX_NUMBER_OF_PUBLIC_EXPONENTS, // Per SymCrypt documentation, only 1 is allowed
+        };
+        unsafe {
+            // SAFETY: FFI calls
+            // No flags specified for SymCryptRsakeyAllocate
+            let rsa_key = Box::pin(symcrypt_sys::SymCryptRsakeyAllocate(&rsa_params, 0));
+            RsaKeyPair {
+                inner: rsa_key,
+                key_mode: key_mode,
+                key_usage: key_usage,
+                num_p_exp: MAX_NUMBER_OF_PUBLIC_EXPONENTS,
+            }
+        }
+    }
+
+    /// `generate_key()` generates a random Rsa key based on the parameters passed into [`RsaKeyPair::new()`].
+    /// 
+    /// `generate_key()` can only be called after space for the key has been allocated through [`RsaKeyPair::new()`].
+    /// 
+    /// `pub_exp` takes in an `Option<u64>` that is the public exponent. If `None` is provided, the default `2^16 +1` will be used.
+    pub fn generate_key(&mut self, pub_exp: Option<u64>) -> Result<(), SymCryptError> {
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptRsakeyGenerate(
+                *self.inner,
+                [pub_exp.unwrap_or(DEFAULT_PUBLIC_EXPONENT)].as_ptr(), // if no public exponent is provided, use the default ( 2^16 + 1 )
+                self.num_p_exp,
+                self.key_usage.to_flag(),
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// `set_public_only()` sets only the public key information onto the [`RsaKeyPair`]. 
+    /// 
+    /// `modulus_buffer` takes in a reference to a byte array that contains the modulus of the Rsa key.
+    /// 
+    /// `pub_exp` takes in a `u64` that is the public exponent.
+    /// 
+    /// `num_format` takes in a [`NumberFormat`] that specifies either [`NumberFormat::LSB`] or [`NumberFormat::MSB`] which must match ALL inputs.
+    pub fn set_public_only(
+        &mut self,
+        modulus_buffer: &[u8],
+        pub_exp: u64,
+        num_format: NumberFormat,
+    ) -> Result<(), SymCryptError> {
+        unsafe {
+            // SAFETY: FFI calls
+            // When only setting the public key, ppPrimes, pcbPrimes and nPrimes can be NULL, NULL and 0
+            match symcrypt_sys::SymCryptRsakeySetValue(
+                modulus_buffer.as_ptr(),
+                modulus_buffer.len() as symcrypt_sys::SIZE_T,
+                [pub_exp].as_ptr(),
+                self.num_p_exp,
+                ptr::null_mut(), 
+                ptr::null_mut(),
+                0,
+                num_format.to_num_format(),
+                self.key_usage.to_flag(),
+                *self.inner,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// `set_key_pair()` sets both the public and private key information onto [`RsaKeyPair`].
+    /// 
+    /// `modulus_buffer` takes in a reference to a byte array that contains the modulus of the Rsa key.
+    /// 
+    /// `pub_exp` takes in a `u64` that is the public exponent.
+    /// 
+    /// `p` takes in reference to a byte array that contains the first prime.
+    /// 
+    /// `q` takes in reference to a byte array that contains the second prime.
+    /// 
+    /// `num_format` takes in a [`NumberFormat`] that specifies either [`NumberFormat::LSB`] or [`NumberFormat::MSB`] which must match ALL inputs.
+    pub fn set_key_pair(
+        &mut self,
+        modulus_buffer: &[u8],
+        pub_exp: u64,         
+        p: &[u8],              
+        q: &[u8],            
+        num_format: NumberFormat, 
+    ) -> Result<(), SymCryptError> {
+
+        // Construct the primes_ptr and primes_len_ptr for SymCryptRsakeyValue consumption
+        let primes_ptr = [p.as_ptr(), q.as_ptr()].as_mut_ptr();
+        let primes_len_ptr = [
+            p.len() as symcrypt_sys::SIZE_T,
+            q.len() as symcrypt_sys::SIZE_T,
+        ]
+        .as_mut_ptr();
+
+        unsafe {
+            // SAFETY: FFI calls
+            // nPrimes must be 2, since this is a key pair.
+            match symcrypt_sys::SymCryptRsakeySetValue(
+                modulus_buffer.as_ptr(),
+                modulus_buffer.len() as symcrypt_sys::SIZE_T,
+                [pub_exp].as_ptr(),
+                self.num_p_exp,
+                primes_ptr,
+                primes_len_ptr,            
+                2 as symcrypt_sys::UINT32,
+                num_format.to_num_format(),
+                self.key_usage.to_flag(),
+                *self.inner,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// `has_private_key()` returns a `bool` indicating if there is a private key associated with the [`RsaKeyPair`].
+    pub fn has_private_key(&self) -> bool {
+        return self.key_mode == RsaKeyMode::KeyPair
+        // ! REVIEW: can call 
+        // SymCryptRsakeyHasPrivateKey(*self.inner) != 0 
+        // There is no direct translation from BOOLEAN from C -> bool on Rust, we already have the state, we can save a call to SymCrypt
+    }
+
+    /// `size_of_modulus()` returns a `u32` indicating the size of the modulus on the [`RsaKeyPair`].
+    pub fn size_of_modulus(&self) -> u32 {
+        unsafe {
+            // SAFETY: FFI calls
+            symcrypt_sys::SymCryptRsakeySizeofModulus(*self.inner)
+        }
+    }
+
+    /// `size_of_public_exponent()` returns a `u32` represents the size of the public exponent associated with the [`RsaKeyPair`].
+    pub fn size_of_public_exponent(&self) -> u32 {
+        unsafe {
+            // SAFETY: FFI calls
+            // Only one public exponent is supported, so the only valid index is 0.
+            symcrypt_sys::SymCryptRsakeySizeofPublicExponent(*self.inner, 0)
+        }
+    }
+
+    /// `size_of_prime()` returns the size in bytes of a byte array large enough to store the selected prime of the key.
+    ///
+    /// `index` takes in a [`PrimeIndex`] which represents either the [`PrimeIndex::First`] or [`PrimeIndex::Second`] index for the primes.   
+    pub fn size_of_prime(&self, index: PrimeIndex) -> u32 {
+        unsafe {
+            // SAFETY: FFI calls
+            // Currently, only two prime RSA is supported, i.e. the only valid indexes are 0 and 1
+            symcrypt_sys::SymCryptRsakeySizeofPrime(*self.inner, index.to_u32())
+        }
+    }
+
+    /// `number_of_pub_exponents()` returns the number of public exponents associated with the [`RsaKeyPair`].
+    pub fn number_of_pub_exponents(&self) -> u32 {
+
+        // The only supported number of public exponents is 1
+        MAX_NUMBER_OF_PUBLIC_EXPONENTS 
+
+        // !REVIEW: from all documentation that I can see the number of public exponents can only be 1, and 0 is used to trigger a default option.
+        // do we want to include this accessor? Instead of hard coding, we can call SymCryptRsakeyGetNumberOfPublicExponents, but it seems like a waste of a call to SymCrypt.
+        // can we remove this entirely? based on offline convo, the number of exponents should always be 1
+    }
+
+    /// `number_of_pub_primes()` returns a `u32` representing the number of primes associated with the [`RsaKeyPair`]
+    pub fn number_of_pub_primes(&self) -> u32 {
+        self.key_mode.to_u32()
+        // !REVIEW: Can call SymCryptRsakeyGetNumberOfPrimes() instead, but it's a wasteful call since we store the number on the state.
+    }
+
+
+    // !REVIEW: instead of using in/out buffers for the get functions, we can use Vec<> which will be slower but more robust, and will not require the user to know the len of the fields,
+    //  Or we could instead return a struct with the info
+//       pub struct KeyReturnValue {
+//          key_mode : RsaKeyMode,
+//          modulus: u64,
+//          p: &[u8],
+//          q: &[u8],
+//        }
+    
+
+
+    /// `get_key_pair_value()` will take in and modify buffers for a [`RsaKeyPair`] that has a private and public key associated. 
+    /// 
+    /// `modulus_buffer` is a mutable buffer to a byte array that will be filled with the modulus of the Rsa key.
+    /// 
+    /// `pub_exp` is a mutable buffer to an array that will be filled with the public exponent of the Rsa key.
+    /// 
+    /// `p` is a mutable buffer to a byte array that will be filled with the first prime of the Rsa key.
+    /// 
+    /// `q` is a mutable buffer to a byte array that will be filled with the second prime of the Rsa key.
+    /// 
+    /// `num_format` takes in a [`NumberFormat`] that specifies either [`NumberFormat::LSB`] or [`NumberFormat::MSB`] which must match ALL inputs.
+    pub fn get_key_pair_value(
+        &mut self,
+        modulus_buffer: &mut [u8],
+        pub_exp: &mut [u64],
+        p: &mut [u8],
+        q: &mut [u8],
+        num_format: NumberFormat,
+    ) -> Result<(), SymCryptError> {
+        let primes_prt = [p.as_mut_ptr(), q.as_mut_ptr()].as_mut_ptr();
+        let primes_len = [
+            p.len() as symcrypt_sys::SIZE_T,
+            q.len() as symcrypt_sys::SIZE_T,
+        ]
+        .as_mut_ptr();
+        unsafe {
+            // SAFETY: FFI calls
+            // nPrimes must be 2, since this is a key pair.
+            match symcrypt_sys::SymCryptRsakeyGetValue(
+                *self.inner,
+                modulus_buffer.as_mut_ptr(),
+                modulus_buffer.len() as symcrypt_sys::SIZE_T,
+                pub_exp.as_mut_ptr(),
+                self.num_p_exp,
+                primes_prt,
+                primes_len,     
+                2 as symcrypt_sys::UINT32, 
+                num_format.to_num_format(),
+                self.key_usage.to_flag(),
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// `get_public_key_value()` will take in and modify buffers for a [`RsaKeyPair`] that has only a public key assoicated
+    /// 
+    /// `modulus_buffer` is a mutable buffer to a byte array that will be filled with the modulus of the Rsa key
+    /// 
+    /// `pub_exp` is a mutable buffer to an array that will be filled with the public exponent of the Rsa key
+    /// 
+    /// `num_format` takes in a [`NumberFormat`] that specifies either [`NumberFormat::LSB`] or [`NumberFormat::MSB`] which must match ALL inputs.
+    pub fn get_public_key_value(
+        &mut self,
+        modulus_buffer: &mut [u8],
+        pub_exp: &mut [u64],
+        num_format: NumberFormat,
+    ) -> Result<(), SymCryptError> {
+        unsafe {
+            // SAFETY: FFI calls
+            // When only getting the public key, ppPrimes, pcbPrimes and nPrimes can be NULL, NULL and 0.
+            match symcrypt_sys::SymCryptRsakeyGetValue(
+                *self.inner,
+                modulus_buffer.as_mut_ptr(),
+                modulus_buffer.len() as symcrypt_sys::SIZE_T,
+                pub_exp.as_mut_ptr(),
+                self.num_p_exp,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                0, 
+                num_format.to_num_format(),
+                self.key_usage.to_flag(),
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// `get_crt_value()` returns the crt values of the Crt key material from a [`RsaKeyPair`].
+    /// 
+    /// `crt` is a mutable slice of mutable slices, where each inner slice will be filled with a Crt exponent.
+    ///  
+    /// `crt_coefficent` is a mutable slice that will be filled with the Crt coefficient (`q^-1 mod p`).
+    /// 
+    /// `private_exponent` is a mutable slice that will be filled with the private exponent (`d`).
+    /// 
+    pub fn get_crt_value(
+        &mut self,
+        crt: &mut [&mut [u8]],
+        crt_coefficent: &mut [u8],
+        private_exponent: &mut [u8],
+        num_format: NumberFormat,
+    ) -> Result<(), SymCryptError> {
+        let mut crt_pointers: Vec<*mut u8> = Vec::with_capacity(crt.len());
+        let mut pcb_crt: Vec<symcrypt_sys::SIZE_T> = Vec::with_capacity(crt.len());
+
+        for c in crt.iter_mut() {
+            crt_pointers.push(c.as_mut_ptr()); // Collect mutable pointers
+            pcb_crt.push(c.len() as symcrypt_sys::SIZE_T); // Collect lengths
+        }
+
+        let crt_pointers_prt = crt_pointers.as_mut_ptr();
+        let pcb_crt_ptr = pcb_crt.as_mut_ptr();
+
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptRsakeyGetCrtValue(
+                *self.inner,
+                crt_pointers_prt,
+                pcb_crt_ptr,
+                crt.len().try_into().unwrap(),
+                crt_coefficent.as_mut_ptr(),
+                crt_coefficent.len() as symcrypt_sys::SIZE_T,
+                private_exponent.as_mut_ptr(),
+                private_exponent.len() as symcrypt_sys::SIZE_T,
+                num_format.to_num_format(),
+                self.key_usage.to_flag(),
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// `get_key_mode()` returns the [`RsaKeyMode`] associated with the [`RsaKeyPair`]
+    pub fn get_key_mode(&self) -> RsaKeyMode {
+        self.key_mode
+    }
+
+    /// `get_key_usage()` returns the [`RsaKeyUsage`] associated with the [`RsaKeyPair`]
+    pub fn get_key_usage(&self) -> RsaKeyUsage {
+        self.key_usage
+    }
+    
+}
+
+impl Drop for RsaKeyPair {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: FFI calls
+            symcrypt_sys::SymCryptRsakeyFree(*self.inner);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rsa_key_generate_new_key_pass() {
+        let mut my_key = RsaKeyPair::new(2048, RsaKeyMode::PublicOnly, RsaKeyUsage::Sign);
+        let res = my_key.generate_key_in_place(&[65537]);
+    }
+
+    #[test]
+    fn test_rsa_key_generate_new_key_fail() {
+        let mut my_key = RsaKeyPair::new(2048, RsaKeyMode::PublicOnly, RsaKeyUsage::Sign);
+        let res = my_key.generate_key_in_place(&[3]);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_rsa_key_get_methods() {
+        let mut my_key = RsaKeyPair::new(2048, RsaKeyMode::PublicOnly, RsaKeyUsage::Sign);
+        let res = my_key.generate_key_in_place(&[65537]);
+
+        assert_eq!(RsaKeyMode::PublicOnly, my_key.get_key_mode());
+        assert_eq!(RsaKeyUsage::Sign, my_key.get_key_usage());
+        assert!(!my_key.has_private_key()); // Assert only public key
+        assert_eq!(my_key.number_of_pub_primes(), 1);
+        assert!(my_key.size_of_public_exponent(), 1)
+    }
+}

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -70,13 +70,9 @@ pub mod oaep;
 pub mod pkcs1;
 pub mod pss;
 
-/// !Review: Can we revisit RsaKeyUsage? It seems like it is not really needed since we dont actually do anything under the covers for it.
-/// Should we pre-append the 0 if MSB is not set?
-/// !Review: allow SYMCRYPT_FLAG_RSA_PKCS1_OPTIONAL_HASH_OID? for PKCS1?
-///  When the flag is set, this function will do signature verification by not using hash OID when needed
-/// What is cbSalt? can we just always assume it will be the hash length of the HashAlgorithm?
-/// what is the label for OAEP? what can I put in the example?
-/// do we need to export the public key for RsaPublicKey?
+/// !Review: Can we revisit RsaKeyUsage? It seems like it is not really needed since we dont actually do anything under the covers for it. 
+/// @ Mitch are the flags enforced at all by SymCrypt? If it's not, i think it might make it much easier to set symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT | symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN
+/// We can enforce the usage in this layer but i dont feel good straying that far from symcrypt.
 
 // InnerRsaKey is a wrapper around symcrypt_sys::PSYMCRYPT_RSAKEY.
 #[derive(Debug)]
@@ -101,7 +97,7 @@ pub struct RsaKeyPair {
     key_usage: RsaKeyUsage,
 }
 
-/// Rsa Public Key State
+/// Rsa Public Key State.
 ///
 /// [`RsaPublicKey`] represents an Rsa public key and also contains the [`RsaKeyUsage`].
 #[derive(Debug)]
@@ -223,7 +219,7 @@ impl RsaKeyPair {
         let rsa_key = allocate_rsa(2, n_bits_mod)?;
         let u64_pub_exp = load_msb_first_u64(pub_exp)?;
 
-        // Construct the primes_ptr and primes_len_ptr for SymCryptRsakeyValue consumption
+        // Construct the primes_ptr and primes_len_ptr for SymCryptRsaKeyValue consumption
         let primes_ptr = [p.as_ptr(), q.as_ptr()].as_mut_ptr();
         let primes_len_ptr = [
             p.len() as symcrypt_sys::SIZE_T,

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -518,7 +518,6 @@ fn load_msb_first_u64(src: &[u8]) -> Result<u64, SymCryptError> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::NumberFormat;
 
     #[test]
     fn test_generate_new_default_exponent() {

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -1,21 +1,21 @@
-//! Rsa functions. For further documentation please refer to symcrypt.h
+//! RSA functions related to creating a RSA Key. For further documentation please refer to symcrypt.h
 //!
 //! This module provides a way to create and use RSA keys.
 //!
-//! There are two types of key objects, [`RsaKeyPair`] and [`RsaPublicKey`].
-//! From these objects you can sign, encrypt, decrypt, and verify data via pkcs1, pss, or oaep.
+//! The [`RsaKey`] struct is a wrapper around SymCrypt's RSA key object. It can hold either just a RSA public key, or a RSA key pair.
+//! From [`RsaKey`] you can sign, encrypt, decrypt, and verify data via pkcs1, pss, or oaep.
 //!
 //! For more information on [`pkcs1`], [`pss`], and [`oaep`] please refer to their respective modules.
 //!
 //! # Examples
 //!
-//! ## Generating a random RsaKeyPair object.
+//! ## Generating a random RsaKey object.
 //!
 //! ```rust
-//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::rsa::{RsaKey, RsaKeyUsage};
 //!
-//! // Generate a new RsaKeyPair object with a 2048 bit modulus and default public exponent.
-//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign).unwrap();
+//! // Generate a new RsaKey object with a 2048 bit modulus and default public exponent.
+//! let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Sign).unwrap();
 //!
 //! // key_pair can now be used via pkcs1, pss, or oaep.
 //!
@@ -28,10 +28,10 @@
 //! let key_pair_blob = key_pair.export_key_pair_blob().unwrap();
 //! ```
 //!
-//! ## Setting a RsaPublicKey object from parameters.
+//! ## Setting RsaKey's public key from parameters.
 //!
 //! ```rust
-//! use symcrypt::rsa::{RsaPublicKey, RsaKeyUsage};
+//! use symcrypt::rsa::{RsaKey, RsaKeyUsage};
 //!
 //! // Set an RsaPublicKey based on the modulus, public exponent, and key usage.
 //! let modulus = [
@@ -52,9 +52,12 @@
 //! ];
 //!
 //! let pub_exp = [0, 0, 0, 0, 0, 1, 0, 1];
-//! let public_key = RsaPublicKey::set_public_key(&modulus, &pub_exp, RsaKeyUsage::Sign).unwrap();
+//! let public_key = RsaKey::set_public_key(&modulus, &pub_exp, RsaKeyUsage::Sign).unwrap();
 //!    
 //! // public_key can now be used via pkcs1, pss, or oaep.
+//!
+//! // RsaKey does not have a private key attached.
+//! assert_eq!(public_key.has_private_key(), false);
 //!
 //! // get the size of the modulus and the size of the public exponent.
 //! let modulus_size = public_key.get_size_of_modulus();
@@ -84,26 +87,8 @@ impl Drop for InnerRsaKey {
     }
 }
 
-/// Rsa Public and Private Key State.
-///
-/// [`RsaKeyPair`] represents an Rsa key pair and also contains the [`RsaKeyUsage`].
-#[derive(Debug)]
-pub struct RsaKeyPair {
-    inner: InnerRsaKey,
-    key_usage: RsaKeyUsage,
-}
-
-/// Rsa Public Key State.
-///
-/// [`RsaPublicKey`] represents an Rsa public key and also contains the [`RsaKeyUsage`].
-#[derive(Debug)]
-pub struct RsaPublicKey {
-    inner: InnerRsaKey,
-    key_usage: RsaKeyUsage,
-}
-
 #[derive(Debug, Copy, Clone, PartialEq)]
-/// `RsaKeyUsage` will indicate if the [`RsaKeyPair`] or [`RsaPublicKey`] will be used for [`RsaKeyUsage::Sign`] or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`].
+/// `RsaKeyUsage` will indicate if the [`RsaKey`] will be used for [`RsaKeyUsage::Sign`] or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`].
 /// This check is enforced by SymCrypt and will return [`SymCryptError::InvalidArgument`] if the key is used for the wrong purpose.
 pub enum RsaKeyUsage {
     // When using [`RsaKeyUsage::Sign`], the intended usage for the key will be only Signing.
@@ -131,7 +116,7 @@ impl RsaKeyUsage {
 
 #[derive(Debug)]
 #[allow(dead_code)]
-/// [`RsaKeyPairExportBlob`] holds the values of the `[RsaKeyPair]` when the key pair is exported.  
+/// [`RsaKeyPairExportBlob`] holds the values of the [`RsaKey`] when exporting the public and private key from [`RsaKey`]
 /// NOTE: SymCrypt does not prepend leading 0's if the MSB is set.
 pub struct RsaKeyPairExportBlob {
     pub modulus: Vec<u8>,
@@ -146,26 +131,36 @@ pub struct RsaKeyPairExportBlob {
 
 #[derive(Debug)]
 #[allow(dead_code)]
-/// [`RsaPublicKeyExportBlob`] holds the values of the `[RsaPublicKey]` when the key is exported.
+/// [`RsaPublicKeyExportBlob`] holds the values of the [`RsaKey`] when exporting the public key from [`RsaKey`]
 /// NOTE: SymCrypt does not prepend leading 0's if the MSB is set.
 pub struct RsaPublicKeyExportBlob {
     pub modulus: Vec<u8>,
     pub pub_exp: Vec<u8>,
 }
+#[derive(Debug)]
+/// Rsa Key State Object.
+///
+/// `RsaKey` is a struct that represents a RsaKey. It can hold either just a RSA public key, or a RSA key pair.
+/// To check if they key has a private key attached you can use [`RsaKey::has_private_key()`].
+/// `RsaKey` also has a [`RsaKeyUsage`] attached, to indicate the usage of `RsaKey`.
+pub struct RsaKey {
+    inner: InnerRsaKey,
+    rsa_key_usage: RsaKeyUsage,
+    has_private_key: bool,
+}
 
-/// Impl for RsaKeyPair struct.
-impl RsaKeyPair {
-    /// `generate_new()` generates a random Rsa key based on the provided parameters.
+impl RsaKey {
+    /// `generate_key_pair()` generates a random Rsa key with a public and private key attached based on the provided parameters.
     ///
     /// `n_bits_mod` represents a `u32` that is the desired bit length of the Rsa key, `n_bits_mod` must be at least 1024 bits.
     ///
     /// `pub_exp` takes in an `Option<&[u8]>` that is the public exponent. If `None` is provided, the default `2^16 +1` will be used.
     ///  
-    /// `key_usage` takes in a [`RsaKeyUsage`] and will indicate if this key will be used for [`RsaKeyUsage::Sign`], or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`]
-    pub fn generate_new(
+    /// `rsa_key_usage` takes in a [`RsaKeyUsage`] and will indicate if this key will be used for [`RsaKeyUsage::Sign`], or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`]
+    pub fn generate_key_pair(
         n_bits_mod: u32,
         pub_exp: Option<&[u8]>,
-        key_usage: RsaKeyUsage,
+        rsa_key_usage: RsaKeyUsage,
     ) -> Result<Self, SymCryptError> {
         let (pub_exp_ptr, pub_exp_count) = match pub_exp {
             Some(exp) => {
@@ -183,18 +178,19 @@ impl RsaKeyPair {
                 rsa_key.0,
                 pub_exp_ptr,   // Pointer to the public exponent array or null.
                 pub_exp_count, // Count of public exponents. Will be 1 if Some() is provided, else 0.
-                key_usage.to_symcrypt_flag(),
+                rsa_key_usage.to_symcrypt_flag(),
             ) {
-                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKeyPair {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKey {
                     inner: rsa_key,
-                    key_usage: key_usage,
+                    rsa_key_usage: rsa_key_usage,
+                    has_private_key: true,
                 }),
                 err => Err(err.into()),
             }
         }
     }
 
-    /// `set_key_pair()` sets both the public and private key information onto [`RsaKeyPair`].
+    /// `set_key_pair()` sets both the public and private key information onto [`RsaKey`].
     ///
     /// `modulus_buffer` takes in a `&[u8]` reference to a byte array that contains the modulus of the Rsa key.
     ///
@@ -208,7 +204,7 @@ impl RsaKeyPair {
         pub_exp: &[u8],
         p: &[u8],
         q: &[u8],
-        key_usage: RsaKeyUsage,
+        rsa_key_usage: RsaKeyUsage,
     ) -> Result<Self, SymCryptError> {
         let n_bits_mod = (modulus_buffer.len() as symcrypt_sys::SIZE_T) * 8; // Convert the size from bytes to bits.
         let rsa_key = allocate_rsa(2, n_bits_mod)?;
@@ -232,31 +228,66 @@ impl RsaKeyPair {
                 primes_len_ptr,
                 2 as symcrypt_sys::UINT32,
                 NumberFormat::MSB.to_symcrypt_format(),
-                key_usage.to_symcrypt_flag(),
+                rsa_key_usage.to_symcrypt_flag(),
                 rsa_key.0,
             ) {
-                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKeyPair {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKey {
                     inner: rsa_key,
-                    key_usage: key_usage,
+                    rsa_key_usage: rsa_key_usage,
+                    has_private_key: true,
                 }),
                 err => Err(err.into()),
             }
         }
     }
 
-    /// `get_size_of_primes()` returns a tuple of type `u32` containing the sizes, in bytes, of byte arrays large enough to store each of the two primes of the RSA key.
-    pub fn get_size_of_primes(&self) -> (u32, u32) {
+    /// `set_public_key()` sets only the public key information onto the [`RsaKey`].
+    ///
+    /// `modulus_buffer` takes in a `&[u8]` reference to a byte array that contains the modulus of the Rsa key.
+    ///
+    /// `pub_exp` takes in a `&[u8]` that is an array of bytes representing the public exponent.
+    ///
+    /// `rsa_key_usage` takes in a [`RsaKeyUsage`] and will indicate if this key will be used for [`RsaKeyUsage::Sign`], or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`]
+    pub fn set_public_key(
+        modulus_buffer: &[u8],
+        pub_exp: &[u8],
+        rsa_key_usage: RsaKeyUsage,
+    ) -> Result<Self, SymCryptError> {
+        let n_bits_mod = (modulus_buffer.len() as symcrypt_sys::SIZE_T) * 8; // Convert the size from bytes to bits
+        let rsa_key = allocate_rsa(0, n_bits_mod)?;
+        let u64_pub_exp = load_msb_first_u64(pub_exp)?;
         unsafe {
             // SAFETY: FFI calls
-            // Currently, only two prime RSA is supported, i.e. the only valid indexes are 0 and 1
-            let prime_1 = symcrypt_sys::SymCryptRsakeySizeofPrime(self.inner.0, 0);
-            let prime_2 = symcrypt_sys::SymCryptRsakeySizeofPrime(self.inner.0, 1);
-            (prime_1, prime_2)
+            // When only setting the public key, ppPrimes, pcbPrimes and nPrimes can be NULL, NULL and 0
+            match symcrypt_sys::SymCryptRsakeySetValue(
+                modulus_buffer.as_ptr(),
+                modulus_buffer.len() as symcrypt_sys::SIZE_T,
+                [u64_pub_exp].as_ptr(), // This array has a length of 1.
+                1 as symcrypt_sys::UINT32,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                0,
+                NumberFormat::MSB.to_symcrypt_format(),
+                rsa_key_usage.to_symcrypt_flag(),
+                rsa_key.0,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKey {
+                    inner: rsa_key,
+                    rsa_key_usage: rsa_key_usage,
+                    has_private_key: false,
+                }),
+                err => Err(err.into()),
+            }
         }
     }
 
-    /// `export_key_pair_blob()` returns a [`RsaKeyPairExportBlob`] value.
+    /// `export_key_pair_blob()` returns a [`RsaKeyPairExportBlob`].
+    ///
+    /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
     pub fn export_key_pair_blob(&self) -> Result<RsaKeyPairExportBlob, SymCryptError> {
+        if !self.has_private_key {
+            return Err(SymCryptError::InvalidArgument);
+        }
         // Get size of primes only once
         let (size_p, size_q) = self.get_size_of_primes();
 
@@ -293,7 +324,7 @@ impl RsaKeyPair {
                 primes_len.as_mut_ptr(),
                 2 as symcrypt_sys::UINT32,
                 NumberFormat::MSB.to_symcrypt_format(),
-                self.key_usage.to_symcrypt_flag(),
+                self.rsa_key_usage.to_symcrypt_flag(),
             );
             if result != symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR {
                 return Err(result.into());
@@ -309,7 +340,7 @@ impl RsaKeyPair {
                 private_exponent.as_mut_ptr(),
                 private_exponent.len() as symcrypt_sys::SIZE_T,
                 NumberFormat::MSB.to_symcrypt_format(),
-                self.key_usage.to_symcrypt_flag(),
+                self.rsa_key_usage.to_symcrypt_flag(),
             );
             if result != symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR {
                 return Err(result.into());
@@ -347,7 +378,7 @@ impl RsaKeyPair {
                 ptr::null_mut(),
                 0,
                 NumberFormat::MSB.to_symcrypt_format(),
-                self.key_usage.to_symcrypt_flag(),
+                self.rsa_key_usage.to_symcrypt_flag(),
             ) {
                 symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaPublicKeyExportBlob {
                     modulus: modulus_buffer,
@@ -358,73 +389,24 @@ impl RsaKeyPair {
         }
     }
 
-    /// `get_size_of_modulus()` returns a `u32` representing the (tight) size in bytes of a byte array big enough to store
-    /// the modulus of the key.
-    pub fn get_size_of_modulus(&self) -> u32 {
-        unsafe {
-            // SAFETY: FFI calls
-            symcrypt_sys::SymCryptRsakeySizeofModulus(self.inner.0)
+    /// `has_private_key()` returns true if there is a private key associated with the [`RsaKey`]
+    pub fn has_private_key(&self) -> bool {
+        self.has_private_key
+    }
+
+    /// `get_size_of_primes()` returns a tuple of type `u32` containing the sizes, in bytes, of byte arrays large enough to store each of the two primes of the RSA key.
+    ///
+    /// If the [`RsaKey`] does not have a private key set, the result of `get_size_of_primes()` will be `(0,0)`.
+    pub fn get_size_of_primes(&self) -> (u32, u32) {
+        if !self.has_private_key {
+            return (0, 0);
         }
-    }
-
-    /// `get_size_of_public_exponent()` returns a `u32` representing the (tight) size in bytes of a byte array big enough to store
-    /// the public exponent of the key.
-    pub fn get_size_of_public_exponent(&self) -> u32 {
         unsafe {
             // SAFETY: FFI calls
-            // Only one public exponent is supported, so the only valid index is 0.
-            symcrypt_sys::SymCryptRsakeySizeofPublicExponent(self.inner.0, 0)
-        }
-    }
-
-    /// `get_key_usage` returns the intended usage for the RSA key pair.
-    pub fn get_key_usage(&self) -> RsaKeyUsage {
-        self.key_usage
-    }
-
-    // `inner` gives crate access to the inner symcrypt Rsa Key struct.
-    pub(crate) fn inner(&self) -> symcrypt_sys::PSYMCRYPT_RSAKEY {
-        self.inner.0
-    }
-}
-
-impl RsaPublicKey {
-    /// `set_public_key()` sets only the public key information onto the [`RsaPublicKey`].
-    ///
-    /// `modulus_buffer` takes in a `&[u8]` reference to a byte array that contains the modulus of the Rsa key.
-    ///
-    /// `pub_exp` takes in a `&[u8]` that is an array of bytes representing the public exponent.
-    ///
-    /// `key_usage` takes in a [`RsaKeyUsage`] and will indicate if this key will be used for [`RsaKeyUsage::Sign`], or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`]
-    pub fn set_public_key(
-        modulus_buffer: &[u8],
-        pub_exp: &[u8],
-        key_usage: RsaKeyUsage,
-    ) -> Result<Self, SymCryptError> {
-        let n_bits_mod = (modulus_buffer.len() as symcrypt_sys::SIZE_T) * 8; // Convert the size from bytes to bits
-        let rsa_key = allocate_rsa(0, n_bits_mod)?;
-        let u64_pub_exp = load_msb_first_u64(pub_exp)?;
-        unsafe {
-            // SAFETY: FFI calls
-            // When only setting the public key, ppPrimes, pcbPrimes and nPrimes can be NULL, NULL and 0
-            match symcrypt_sys::SymCryptRsakeySetValue(
-                modulus_buffer.as_ptr(),
-                modulus_buffer.len() as symcrypt_sys::SIZE_T,
-                [u64_pub_exp].as_ptr(), // This array has a length of 1.
-                1 as symcrypt_sys::UINT32,
-                ptr::null_mut(),
-                ptr::null_mut(),
-                0,
-                NumberFormat::MSB.to_symcrypt_format(),
-                key_usage.to_symcrypt_flag(),
-                rsa_key.0,
-            ) {
-                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaPublicKey {
-                    inner: rsa_key,
-                    key_usage: key_usage,
-                }),
-                err => Err(err.into()),
-            }
+            // Currently, only two prime RSA is supported, i.e. the only valid indexes are 0 and 1
+            let prime_1 = symcrypt_sys::SymCryptRsakeySizeofPrime(self.inner.0, 0);
+            let prime_2 = symcrypt_sys::SymCryptRsakeySizeofPrime(self.inner.0, 1);
+            (prime_1, prime_2)
         }
     }
 
@@ -447,12 +429,12 @@ impl RsaPublicKey {
         }
     }
 
-    /// `get_key_usage` returns the intended usage for the RSA public key.
-    pub fn get_key_usage(&self) -> RsaKeyUsage {
-        self.key_usage
+    /// `get_rsa_key_usage()` returns the intended usage for the RSA key pair.
+    pub fn get_rsa_key_usage(&self) -> RsaKeyUsage {
+        self.rsa_key_usage
     }
 
-    // `inner` gives crate access to the inner symcrypt Rsa Key struct.
+    // `inner()` gives crate access to the inner symcrypt Rsa Key object.
     pub(crate) fn inner(&self) -> symcrypt_sys::PSYMCRYPT_RSAKEY {
         self.inner.0
     }
@@ -507,38 +489,70 @@ fn load_msb_first_u64(src: &[u8]) -> Result<u64, SymCryptError> {
     }
 }
 
-// Test invalid keys
-
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
     fn test_generate_new_default_exponent() {
-        let result = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign);
+        let result = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Sign);
         assert!(result.is_ok());
         let key_pair = result.unwrap();
-        assert_eq!(key_pair.get_key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.get_rsa_key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.has_private_key(), true);
     }
 
     #[test]
     fn test_generate_get_then_set() {
-        let result = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign);
+        let result = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Sign);
         assert!(result.is_ok());
         let key_pair = result.unwrap();
-        assert_eq!(key_pair.get_key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.get_rsa_key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.has_private_key(), true);
 
         let blob = key_pair.export_key_pair_blob().unwrap();
-        let new_key_pair = RsaKeyPair::set_key_pair(
+        let new_key_pair = RsaKey::set_key_pair(
             &blob.modulus,
             &blob.pub_exp,
             &blob.p,
             &blob.q,
-            key_pair.key_usage,
+            key_pair.rsa_key_usage,
         )
         .unwrap();
         let blob_2 = new_key_pair.export_key_pair_blob().unwrap();
         assert_eq!(blob_2.crt_coefficient, blob.crt_coefficient);
+    }
+
+    #[test]
+    fn test_get_primes() {
+        let result = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Sign);
+        assert!(result.is_ok());
+        let key_pair = result.unwrap();
+        assert_eq!(key_pair.get_size_of_primes(), (128, 128));
+
+        let modulus = [
+            215, 145, 16, 194, 78, 246, 213, 23, 173, 178, 123, 179, 152, 238, 67, 16, 25, 20, 102,
+            36, 142, 210, 5, 164, 214, 122, 56, 206, 61, 65, 121, 44, 248, 241, 176, 72, 104, 251,
+            188, 59, 107, 251, 214, 238, 237, 49, 27, 224, 96, 114, 82, 54, 116, 238, 151, 56, 73,
+            216, 107, 88, 226, 27, 176, 247, 180, 48, 165, 127, 156, 133, 148, 69, 67, 191, 196,
+            148, 115, 123, 86, 185, 169, 42, 111, 109, 121, 21, 9, 174, 183, 126, 219, 3, 32, 83,
+            183, 63, 98, 253, 243, 108, 26, 9, 75, 68, 33, 248, 71, 223, 51, 231, 153, 194, 233,
+            245, 53, 86, 243, 164, 94, 123, 146, 75, 161, 99, 5, 145, 85, 165, 187, 146, 243, 196,
+            181, 223, 232, 32, 247, 253, 217, 211, 170, 187, 32, 23, 177, 11, 241, 133, 141, 8, 38,
+            124, 133, 88, 81, 230, 110, 200, 219, 28, 149, 77, 25, 163, 18, 75, 183, 210, 68, 0,
+            126, 3, 182, 196, 126, 207, 27, 92, 144, 174, 178, 203, 200, 146, 45, 180, 202, 3, 76,
+            22, 202, 37, 87, 215, 183, 83, 159, 65, 144, 9, 172, 137, 75, 17, 51, 31, 176, 6, 168,
+            197, 156, 195, 253, 36, 71, 64, 125, 253, 126, 155, 169, 79, 180, 233, 157, 193, 100,
+            239, 237, 129, 4, 165, 38, 112, 247, 253, 174, 21, 245, 71, 236, 229, 56, 123, 134, 45,
+            17, 124, 191, 60, 163, 218, 149, 209, 207, 181,
+        ];
+        let pub_exp: u64 = 65537;
+        let result = RsaKey::set_public_key(&modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
+
+        assert!(result.is_ok());
+        let pub_key = result.unwrap();
+
+        assert_eq!(pub_key.get_size_of_primes(), (0, 0));
     }
 
     #[test]
@@ -582,13 +596,14 @@ mod test {
         let pub_exp: u64 = 65537;
 
         let result =
-            RsaKeyPair::set_key_pair(&modulus, &pub_exp.to_be_bytes(), &p, &q, RsaKeyUsage::Sign);
+            RsaKey::set_key_pair(&modulus, &pub_exp.to_be_bytes(), &p, &q, RsaKeyUsage::Sign);
         assert!(result.is_ok());
         let key_pair = result.unwrap();
-        assert_eq!(key_pair.get_key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.get_rsa_key_usage(), RsaKeyUsage::Sign);
         assert_eq!(key_pair.get_size_of_primes(), (128, 128));
         assert_eq!(key_pair.get_size_of_modulus(), 256);
         assert_eq!(key_pair.get_size_of_public_exponent(), 3);
+        assert_eq!(key_pair.has_private_key(), true);
         let key_blob = key_pair.export_key_pair_blob().unwrap();
         assert_eq!(key_blob.modulus, modulus.to_vec());
         assert_eq!(key_blob.p, p);
@@ -614,21 +629,20 @@ mod test {
             17, 124, 191, 60, 163, 218, 149, 209, 207, 181,
         ];
         let pub_exp: u64 = 65537;
-        let result =
-            RsaPublicKey::set_public_key(&modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
+        let result = RsaKey::set_public_key(&modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
 
         assert!(result.is_ok());
         let pub_key = result.unwrap();
 
-        assert_eq!(pub_key.get_key_usage(), RsaKeyUsage::Encrypt);
+        assert_eq!(pub_key.has_private_key(), false);
+        assert_eq!(pub_key.get_rsa_key_usage(), RsaKeyUsage::Encrypt);
         assert_eq!(pub_key.get_size_of_modulus(), 256);
         assert_eq!(pub_key.get_size_of_public_exponent(), 3);
     }
 
-    /// new
     #[test]
     fn test_export_public_key_blob_on_key_pair() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Encrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Encrypt).unwrap();
         let public_key_blob = key_pair.export_public_key_blob().unwrap();
 
         assert_eq!(
@@ -648,7 +662,7 @@ mod test {
         let invalid_prime = vec![0u8; 128]; // Invalid prime p
         let invalid_prime_q = vec![0u8; 128]; // Invalid prime q
 
-        let result = RsaKeyPair::set_key_pair(
+        let result = RsaKey::set_key_pair(
             &invalid_modulus,
             &invalid_pub_exp,
             &invalid_prime,
@@ -664,7 +678,7 @@ mod test {
         let invalid_pub_exp = vec![0u8; 3]; // Invalid public exponent
 
         let result =
-            RsaPublicKey::set_public_key(&invalid_modulus, &invalid_pub_exp, RsaKeyUsage::Encrypt);
+            RsaKey::set_public_key(&invalid_modulus, &invalid_pub_exp, RsaKeyUsage::Encrypt);
         assert!(result.is_err());
     }
 
@@ -690,10 +704,10 @@ mod test {
 
     #[test]
     fn test_generate_with_boundary_key_sizes() {
-        let result = RsaKeyPair::generate_new(512, None, RsaKeyUsage::Sign).unwrap_err();
+        let result = RsaKey::generate_key_pair(512, None, RsaKeyUsage::Sign).unwrap_err();
         assert_eq!(result, SymCryptError::InvalidArgument);
 
-        let result = RsaKeyPair::generate_new(4096, None, RsaKeyUsage::Sign);
+        let result = RsaKey::generate_key_pair(4096, None, RsaKeyUsage::Sign);
         assert!(result.is_ok());
         let key_pair_4096 = result.unwrap();
         assert_eq!(key_pair_4096.get_size_of_modulus(), 4096 / 8);
@@ -702,13 +716,40 @@ mod test {
     #[test]
     fn test_key_deletion() {
         {
-            let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Encrypt).unwrap();
+            let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Encrypt).unwrap();
             let public_key_blob = key_pair.export_public_key_blob().unwrap();
             assert_eq!(
                 public_key_blob.modulus.len(),
                 key_pair.get_size_of_modulus() as usize
             );
-        } // Key pair should be dropped here
+        } // RsaKey should be dropped here
           // If no memory leaks or segmentation faults occur, the test passes.
+    }
+
+    #[test]
+    fn test_export_key_pair_blob_on_public_key() {
+        let modulus = [
+            215, 145, 16, 194, 78, 246, 213, 23, 173, 178, 123, 179, 152, 238, 67, 16, 25, 20, 102,
+            36, 142, 210, 5, 164, 214, 122, 56, 206, 61, 65, 121, 44, 248, 241, 176, 72, 104, 251,
+            188, 59, 107, 251, 214, 238, 237, 49, 27, 224, 96, 114, 82, 54, 116, 238, 151, 56, 73,
+            216, 107, 88, 226, 27, 176, 247, 180, 48, 165, 127, 156, 133, 148, 69, 67, 191, 196,
+            148, 115, 123, 86, 185, 169, 42, 111, 109, 121, 21, 9, 174, 183, 126, 219, 3, 32, 83,
+            183, 63, 98, 253, 243, 108, 26, 9, 75, 68, 33, 248, 71, 223, 51, 231, 153, 194, 233,
+            245, 53, 86, 243, 164, 94, 123, 146, 75, 161, 99, 5, 145, 85, 165, 187, 146, 243, 196,
+            181, 223, 232, 32, 247, 253, 217, 211, 170, 187, 32, 23, 177, 11, 241, 133, 141, 8, 38,
+            124, 133, 88, 81, 230, 110, 200, 219, 28, 149, 77, 25, 163, 18, 75, 183, 210, 68, 0,
+            126, 3, 182, 196, 126, 207, 27, 92, 144, 174, 178, 203, 200, 146, 45, 180, 202, 3, 76,
+            22, 202, 37, 87, 215, 183, 83, 159, 65, 144, 9, 172, 137, 75, 17, 51, 31, 176, 6, 168,
+            197, 156, 195, 253, 36, 71, 64, 125, 253, 126, 155, 169, 79, 180, 233, 157, 193, 100,
+            239, 237, 129, 4, 165, 38, 112, 247, 253, 174, 21, 245, 71, 236, 229, 56, 123, 134, 45,
+            17, 124, 191, 60, 163, 218, 149, 209, 207, 181,
+        ];
+        let pub_exp: u64 = 65537;
+        let result = RsaKey::set_public_key(&modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
+
+        assert!(result.is_ok());
+        let pub_key = result.unwrap();
+        let export_result = pub_key.export_key_pair_blob().unwrap_err();
+        assert_eq!(export_result, SymCryptError::InvalidArgument);
     }
 }

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -1,12 +1,89 @@
-/// Rsa functions. For further documentation please refer to symcrypt.h
-/// TODO rest of the documentation
+//! Rsa functions. For further documentation please refer to symcrypt.h
+//!
+//! This module provides a way to create and use RSA keys.
+//!
+//! There are two types of key objects, [`RsaKeyPair`] and [`RsaPublicKey`].
+//! From these objects you can sign, encrypt, decrypt, and verify data via pkcs1, pss, or oaep.
+//!
+//! For more information on [`pkcs1`], [`pss`], and [`oaep`] please refer to their respective modules.
+//!
+//! # Examples
+//!
+//! ## Generating a random RsaKeyPair object.
+//!
+//! ```rust
+//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
+//!
+//! // Generate a new RsaKeyPair object with a 2048 bit modulus and default public exponent.
+//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign).unwrap();
+//!
+//! // key_pair can now be used via pkcs1, pss, or oaep.
+//!
+//! // Get the size of the modulus, size of the public exponent, and size of the primes.
+//! let modulus_size = key_pair.get_size_of_modulus();
+//! let pub_exp_size = key_pair.get_size_of_public_exponent();
+//! let primes = key_pair.get_size_of_primes();
+//!
+//! // Export the key pair to a blob.
+//! let key_pair_blob = key_pair.export_key_pair_blob().unwrap();
+//! ```
+//!
+//! ## Setting a RsaPublicKey object from parameters.
+//!
+//! ```rust
+//! use symcrypt::rsa::{RsaPublicKey, RsaKeyUsage};
+//!
+//! // Set an RsaPublicKey based on the modulus, public exponent, and key usage.
+//! let modulus = [
+//!     215, 145, 16, 194, 78, 246, 213, 23, 173, 178, 123, 179, 152, 238, 67, 16, 25, 20, 102,
+//!     36, 142, 210, 5, 164, 214, 122, 56, 206, 61, 65, 121, 44, 248, 241, 176, 72, 104, 251,
+//!     188, 59, 107, 251, 214, 238, 237, 49, 27, 224, 96, 114, 82, 54, 116, 238, 151, 56, 73,
+//!     216, 107, 88, 226, 27, 176, 247, 180, 48, 165, 127, 156, 133, 148, 69, 67, 191, 196,
+//!     148, 115, 123, 86, 185, 169, 42, 111, 109, 121, 21, 9, 174, 183, 126, 219, 3, 32, 83,
+//!     183, 63, 98, 253, 243, 108, 26, 9, 75, 68, 33, 248, 71, 223, 51, 231, 153, 194, 233,
+//!     245, 53, 86, 243, 164, 94, 123, 146, 75, 161, 99, 5, 145, 85, 165, 187, 146, 243, 196,
+//!     181, 223, 232, 32, 247, 253, 217, 211, 170, 187, 32, 23, 177, 11, 241, 133, 141, 8, 38,
+//!     124, 133, 88, 81, 230, 110, 200, 219, 28, 149, 77, 25, 163, 18, 75, 183, 210, 68, 0,
+//!     126, 3, 182, 196, 126, 207, 27, 92, 144, 174, 178, 203, 200, 146, 45, 180, 202, 3, 76,
+//!     22, 202, 37, 87, 215, 183, 83, 159, 65, 144, 9, 172, 137, 75, 17, 51, 31, 176, 6, 168,
+//!     197, 156, 195, 253, 36, 71, 64, 125, 253, 126, 155, 169, 79, 180, 233, 157, 193, 100,
+//!     239, 237, 129, 4, 165, 38, 112, 247, 253, 174, 21, 245, 71, 236, 229, 56, 123, 134, 45,
+//!     17, 124, 191, 60, 163, 218, 149, 209, 207, 181,
+//! ];
+//!
+//! let pub_exp = [0, 0, 0, 0, 0, 1, 0, 1];
+//! let public_key = RsaPublicKey::set_public_key(&modulus, &pub_exp, RsaKeyUsage::Sign).unwrap();
+//!    
+//! // public_key can now be used via pkcs1, pss, or oaep.
+//!
+//! // get the size of the modulus and the size of the public exponent.
+//! let modulus_size = public_key.get_size_of_modulus();
+//! let pub_exp_size = public_key.get_size_of_public_exponent();
+//!
+//! // Export the public key to a blob.
+//! let public_key_blob = public_key.export_public_key_blob().unwrap();
+//! ```
+//!
 use crate::errors::SymCryptError;
 use crate::NumberFormat;
 use std::ptr;
 
-/// Create a InnerRsaKey object that drop the allocation when it leaves scope.
+pub mod oaep;
+pub mod pkcs1;
+pub mod pss;
+
+/// !Review: Can we revisit RsaKeyUsage? It seems like it is not really needed since we dont actually do anything under the covers for it.
+/// Should we pre-append the 0 if MSB is not set?
+/// !Review: allow SYMCRYPT_FLAG_RSA_PKCS1_OPTIONAL_HASH_OID? for PKCS1?
+///  When the flag is set, this function will do signature verification by not using hash OID when needed
+/// What is cbSalt? can we just always assume it will be the hash length of the HashAlgorithm?
+/// what is the label for OAEP? what can I put in the example?
+
+// InnerRsaKey is a wrapper around symcrypt_sys::PSYMCRYPT_RSAKEY.
+#[derive(Debug)]
 pub(crate) struct InnerRsaKey(pub(crate) symcrypt_sys::PSYMCRYPT_RSAKEY);
 
+// Must free inner key rather than the outer struct.
 impl Drop for InnerRsaKey {
     fn drop(&mut self) {
         unsafe {
@@ -18,7 +95,8 @@ impl Drop for InnerRsaKey {
 
 /// Rsa Public and Private Key State.
 ///
-/// [`RsaKeyPair`] stores a private and public Rsa key.
+/// [`RsaKeyPair`] represents an Rsa key pair and also contains the [`RsaKeyUsage`].
+#[derive(Debug)]
 pub struct RsaKeyPair {
     inner: InnerRsaKey,
     key_usage: RsaKeyUsage,
@@ -26,63 +104,74 @@ pub struct RsaKeyPair {
 
 /// Rsa Public Key State
 ///
-/// [`RsaPublicKey`] stores an Rsa public key.
+/// [`RsaPublicKey`] represents an Rsa public key and also contains the [`RsaKeyUsage`].
+#[derive(Debug)]
 pub struct RsaPublicKey {
     inner: InnerRsaKey,
     key_usage: RsaKeyUsage,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-/// `RsaKeyUsage` will indicate if the [`RsaKeyPair`] or [`RsaPublicKey`] will be used for [`RsaKeyUsage::Sign`] or [`RsaKeyUsage::Encrypt`].
+/// `RsaKeyUsage` will indicate if the [`RsaKeyPair`] or [`RsaPublicKey`] will be used for [`RsaKeyUsage::Sign`] or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`].
+/// This is to maintain interop with legacy Windows code and does not enforce any checks under the covers. The caller is responsible for ensuring the key is used correctly.
 pub enum RsaKeyUsage {
-
     // When using [`RsaKeyUsage::Sign`], the intended usage for the key will be only Signing.
     Sign,
 
-    /// When using [`RsaKeyUsage::Encrypt`], the intended usage for the key can be either Signing or Encryption.
+    /// When using [`RsaKeyUsage::Encrypt`], the intended usage for the key will be only Encryption.
     Encrypt,
+
+    /// When using [RsaKeyUsage::SignAndEncrypt`], the intended usage for the key can be either Signing or Encryption.
+    SignAndEncrypt,
 }
 
-// to_symcrypt_flag() is only needed internally and should not be exposed to caller.
+// to_symcrypt_flag converts the RsaKeyUsage to the corresponding SymCrypt flag and only needed internally.
 impl RsaKeyUsage {
     pub(crate) fn to_symcrypt_flag(&self) -> symcrypt_sys::UINT32 {
         match self {
             RsaKeyUsage::Sign => symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN,
-            RsaKeyUsage::Encrypt => symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT | symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN ,
+            RsaKeyUsage::Encrypt => symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT,
+            RsaKeyUsage::SignAndEncrypt => {
+                symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT | symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN
+            }
         }
     }
 }
 
 #[derive(Debug)]
 #[allow(dead_code)]
-/// `[RsaKeyPairExportBlob]` holds the values of the `[RsaKeyPair]` when the key pair is exported.  
+/// [`RsaKeyPairExportBlob`] holds the values of the `[RsaKeyPair]` when the key pair is exported.  
+/// NOTE: SymCrypt does not pre-append leading 0's if the MSB is set.
 pub struct RsaKeyPairExportBlob {
-    modulus: Vec<u8>,
-    pub_exp: Vec<u8>,
-    p: Vec<u8>,
-    q: Vec<u8>,
-    d_p: Vec<u8>,
-    d_q: Vec<u8>,
-    crt_coefficient: Vec<u8>,
-    private_exp: Vec<u8>,
+    pub modulus: Vec<u8>,
+    pub pub_exp: Vec<u8>,
+    pub p: Vec<u8>,
+    pub q: Vec<u8>,
+    pub d_p: Vec<u8>,
+    pub d_q: Vec<u8>,
+    pub crt_coefficient: Vec<u8>,
+    pub private_exp: Vec<u8>,
 }
 
 #[derive(Debug)]
 #[allow(dead_code)]
-/// `[RsaPublicKeyExportBlob]` holds the values of the `[RsaPublicKey]` when the key is exported.
+/// [`RsaPublicKeyExportBlob`] holds the values of the `[RsaPublicKey]` when the key is exported.
+/// NOTE: SymCrypt does not pre-append leading 0's if the MSB is set.
 pub struct RsaPublicKeyExportBlob {
-    modulus: Vec<u8>,
-    pub_exp: Vec<u8>,
+    pub modulus: Vec<u8>,
+    pub pub_exp: Vec<u8>,
 }
 
+/// Impl for RsaKeyPair struct.
 impl RsaKeyPair {
     /// `generate_new()` generates a random Rsa key based on the provided parameters.
     ///
-    /// `n_bits_mod` represents the desired bit length of the Rsa Key.
+    /// `n_bits_mod` represents a `u32` that is the desired bit length of the Rsa key, `n_bits_mod` must be at least 1024 bits.
+    ///
     ///
     /// `pub_exp` takes in an `Option<u64>` that is the public exponent. If `None` is provided, the default `2^16 +1` will be used.
     ///  
-    /// `key_usage` will indicate if this key will be used for [`RsaKeyUsage::Sign`] or [`RsaKeyUsage::Encrypt`]
+    /// `key_usage` takes in a [`RsaKeyUsage`] and will indicate if this key will be used for [`RsaKeyUsage::Sign`], or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`]
     pub fn generate_new(
         n_bits_mod: u32,
         pub_exp: Option<&[u8]>,
@@ -92,18 +181,18 @@ impl RsaKeyPair {
             Some(exp) => {
                 let u64_pub_exp = load_msb_first_u64(exp)?;
                 ([u64_pub_exp].as_ptr(), 1) // This array has a length of 1.
-            },
+            }
             None => (ptr::null(), 0), // If no public exponent is provided, use null and count 0 which will notify SymCrypt to use their default exponent.
         };
-    
+
         let rsa_key = allocate_rsa(2, n_bits_mod)?;
-    
+
         unsafe {
             // SAFETY: FFI calls
             match symcrypt_sys::SymCryptRsakeyGenerate(
                 rsa_key.0,
-                pub_exp_ptr, // Pointer to the public exponent array or null.
-                pub_exp_count, // Count of public exponents.
+                pub_exp_ptr,   // Pointer to the public exponent array or null.
+                pub_exp_count, // Count of public exponents. Will be 1 if Some() is provided, else 0.
                 key_usage.to_symcrypt_flag(),
             ) {
                 symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKeyPair {
@@ -117,13 +206,13 @@ impl RsaKeyPair {
 
     /// `set_key_pair()` sets both the public and private key information onto [`RsaKeyPair`].
     ///
-    /// `modulus_buffer` takes in a reference to a byte array that contains the modulus of the Rsa key.
+    /// `modulus_buffer` takes in a `&[u8]` reference to a byte array that contains the modulus of the Rsa key.
     ///
     /// `pub_exp` takes in a `&[u8]` that is the public exponent represented by an array of bytes.
     ///
-    /// `p` takes in reference to a byte array that contains the first prime.
+    /// `p` takes in a `&[u8]` reference to a byte array that contains the first prime.
     ///
-    /// `q` takes in reference to a byte array that contains the second prime.
+    /// `q` takes in a `&[u8]` reference to a byte array that contains the second prime.
     pub fn set_key_pair(
         modulus_buffer: &[u8],
         pub_exp: &[u8],
@@ -147,8 +236,8 @@ impl RsaKeyPair {
             match symcrypt_sys::SymCryptRsakeySetValue(
                 modulus_buffer.as_ptr(),
                 modulus_buffer.len() as symcrypt_sys::SIZE_T,
-                [u64_pub_exp].as_ptr(), // This array has a length of 1.
-                1 as symcrypt_sys::UINT32,
+                [u64_pub_exp].as_ptr(),    // This array has a length of 1.
+                1 as symcrypt_sys::UINT32, // Must be 1.
                 primes_ptr,
                 primes_len_ptr,
                 2 as symcrypt_sys::UINT32,
@@ -165,7 +254,7 @@ impl RsaKeyPair {
         }
     }
 
-    /// `size_of_primes()` returns a tuple containing the sizes, in bytes, of byte arrays large enough to store each of the two primes of the RSA key.
+    /// `size_of_primes()` returns a tuple of type `u32` containing the sizes, in bytes, of byte arrays large enough to store each of the two primes of the RSA key.
     pub fn size_of_primes(&self) -> (u32, u32) {
         unsafe {
             // SAFETY: FFI calls
@@ -176,13 +265,13 @@ impl RsaKeyPair {
         }
     }
 
-    /// `export_key_pair_blob()` returns a [`RsaKeyPairBlob`] value.
+    /// `export_key_pair_blob()` returns a [`RsaKeyPairExportBlob`] value.
     pub fn export_key_pair_blob(&self) -> Result<RsaKeyPairExportBlob, SymCryptError> {
         // Get size of primes only once
         let (size_p, size_q) = self.size_of_primes();
 
-        // Allocate buffers for filling RsaKeyPairBlob
-        let mut modulus_buffer = vec![0u8; self.size_of_modulus() as usize];
+        // Allocate buffers for filling RsaKeyPairExportBlob
+        let mut modulus_buffer = vec![0u8; self.get_size_of_modulus() as usize];
         let mut pub_exp = vec![0u64; 1];
         let mut p = vec![0u8; size_p as usize];
         let mut q = vec![0u8; size_q as usize];
@@ -191,7 +280,7 @@ impl RsaKeyPair {
         let mut d_q = vec![0u8; size_q as usize];
 
         let mut crt_coefficient = vec![0u8; size_p as usize];
-        let mut private_exponent = vec![0u8; self.size_of_modulus() as usize];
+        let mut private_exponent = vec![0u8; self.get_size_of_modulus() as usize];
 
         let mut primes_len = [
             p.len() as symcrypt_sys::SIZE_T,
@@ -253,7 +342,7 @@ impl RsaKeyPair {
 
     /// `export_public_key_blob()` will export a [`RsaPublicKey`].
     pub fn export_public_key_blob(&self) -> Result<RsaPublicKeyExportBlob, SymCryptError> {
-        let mut modulus_buffer = vec![0u8; self.size_of_modulus() as usize];
+        let mut modulus_buffer = vec![0u8; self.get_size_of_modulus() as usize];
         let mut pub_exp = vec![0u64; 1];
         unsafe {
             // SAFETY: FFI calls
@@ -279,9 +368,9 @@ impl RsaKeyPair {
         }
     }
 
-    /// `size_of_modulus()` returns a `u32` representing the (tight) size in bytes of a byte array big enough to store
+    /// `get_size_of_modulus()` returns a `u32` representing the (tight) size in bytes of a byte array big enough to store
     /// the modulus of the key.
-    pub fn size_of_modulus(&self) -> u32 {
+    pub fn get_size_of_modulus(&self) -> u32 {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptRsakeySizeofModulus(self.inner.0)
@@ -298,28 +387,29 @@ impl RsaKeyPair {
         }
     }
 
-    /// `key_usage` returns the intended usage for the RSA key pair.
-    pub fn key_usage(&self) -> RsaKeyUsage {
+    /// `get_key_usage` returns the intended usage for the RSA key pair.
+    pub fn get_key_usage(&self) -> RsaKeyUsage {
         self.key_usage
     }
 
-    /// `inner` gives crate access to the inner symcrypt Rsa Key struct.
-    pub(crate) fn inner(&self) -> symcrypt_sys::PSYMCRYPT_RSAKEY  {
+    // `inner` gives crate access to the inner symcrypt Rsa Key struct.
+    pub(crate) fn inner(&self) -> symcrypt_sys::PSYMCRYPT_RSAKEY {
         self.inner.0
     }
 }
 
-
 impl RsaPublicKey {
     /// `set_public_key()` sets only the public key information onto the [`RsaPublicKey`].
     ///
-    /// `modulus_buffer` takes in a reference to a byte array that contains the modulus of the Rsa key.
+    /// `modulus_buffer` takes in a `&[u8]` reference to a byte array that contains the modulus of the Rsa key.
     ///
     /// `pub_exp` takes in a `&[u8]` that is an array of bytes representing the public exponent.
+    ///
+    /// `key_usage` takes in a [`RsaKeyUsage`] and will indicate if this key will be used for [`RsaKeyUsage::Sign`], or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`]
     pub fn set_public_key(
         modulus_buffer: &[u8],
-        pub_exp: &[u8], 
-        key_usage: RsaKeyUsage, // !Review should we let the caller deal with this? 
+        pub_exp: &[u8],
+        key_usage: RsaKeyUsage,
     ) -> Result<Self, SymCryptError> {
         let n_bits_mod = (modulus_buffer.len() as u32) * 8; // Convert the size from bytes to bits
         let rsa_key = allocate_rsa(0, n_bits_mod)?;
@@ -336,7 +426,7 @@ impl RsaPublicKey {
                 ptr::null_mut(),
                 0,
                 NumberFormat::MSB.to_symcrypt_format(),
-                key_usage.to_symcrypt_flag(), // !Review: can set this sign and encrypt
+                key_usage.to_symcrypt_flag(),
                 rsa_key.0,
             ) {
                 symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaPublicKey {
@@ -348,9 +438,9 @@ impl RsaPublicKey {
         }
     }
 
-    /// `size_of_modulus()` returns a `u32` representing the (tight) size in bytes of a byte array big enough to store
+    /// `get_size_of_modulus()` returns a `u32` representing the (tight) size in bytes of a byte array big enough to store
     /// the modulus of the key.
-    pub fn size_of_modulus(&self) -> u32 {
+    pub fn get_size_of_modulus(&self) -> u32 {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptRsakeySizeofModulus(self.inner.0)
@@ -367,17 +457,16 @@ impl RsaPublicKey {
         }
     }
 
-    /// `key_usage` returns the intended usage for the RSA public key.
-    pub fn key_usage(&self) -> RsaKeyUsage {
+    /// `get_key_usage` returns the intended usage for the RSA public key.
+    pub fn get_key_usage(&self) -> RsaKeyUsage {
         self.key_usage
     }
 
-    /// `inner` gives crate access to the inner symcrypt Rsa Key struct.
-    pub(crate) fn inner(&self) -> symcrypt_sys::PSYMCRYPT_RSAKEY  {
+    // `inner` gives crate access to the inner symcrypt Rsa Key struct.
+    pub(crate) fn inner(&self) -> symcrypt_sys::PSYMCRYPT_RSAKEY {
         self.inner.0
     }
 }
-
 
 // Utility function to reduce common RSA allocation call
 fn allocate_rsa(n_primes: u32, n_bits_mod: u32) -> Result<InnerRsaKey, SymCryptError> {
@@ -391,22 +480,18 @@ fn allocate_rsa(n_primes: u32, n_bits_mod: u32) -> Result<InnerRsaKey, SymCryptE
         // SAFETY: FFI calls
         let result = symcrypt_sys::SymCryptRsakeyAllocate(&rsa_params, 0);
         if result == ptr::null_mut() {
-            return Err(SymCryptError::AuthenticationFailure)
+            return Err(SymCryptError::AuthenticationFailure);
         }
         Ok(InnerRsaKey(result))
     }
 }
 
-/// Utility function to store a `u64` into a new byte vector in big-endian format.
+// Utility function to store a `u64` into a new byte vector in big-endian format.
 fn store_msb_first_u64(value: u64, size: u32) -> Result<Vec<u8>, SymCryptError> {
     let mut dst = vec![0u8; size as usize]; // Allocate tight size in bytes for storing public exponent
     unsafe {
         // SAFETY: FFI calls
-        match symcrypt_sys::SymCryptStoreMsbFirstUint64(
-            value,
-            dst.as_mut_ptr(),
-            size as u64,
-        ) {
+        match symcrypt_sys::SymCryptStoreMsbFirstUint64(value, dst.as_mut_ptr(), size as u64) {
             symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(dst),
             err => Err(SymCryptError::from(err)),
         }
@@ -429,6 +514,8 @@ fn load_msb_first_u64(src: &[u8]) -> Result<u64, SymCryptError> {
     }
 }
 
+// Test invalid keys
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -439,7 +526,7 @@ mod test {
         let result = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign);
         assert!(result.is_ok());
         let key_pair = result.unwrap();
-        assert_eq!(key_pair.key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.get_key_usage(), RsaKeyUsage::Sign);
     }
 
     #[test]
@@ -447,10 +534,17 @@ mod test {
         let result = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign);
         assert!(result.is_ok());
         let key_pair = result.unwrap();
-        assert_eq!(key_pair.key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.get_key_usage(), RsaKeyUsage::Sign);
 
         let blob = key_pair.export_key_pair_blob().unwrap();
-        let new_key_pair = RsaKeyPair::set_key_pair( &blob.modulus, &blob.pub_exp, &blob.p, &blob.q, key_pair.key_usage).unwrap();
+        let new_key_pair = RsaKeyPair::set_key_pair(
+            &blob.modulus,
+            &blob.pub_exp,
+            &blob.p,
+            &blob.q,
+            key_pair.key_usage,
+        )
+        .unwrap();
         let blob_2 = new_key_pair.export_key_pair_blob().unwrap();
         assert_eq!(blob_2.crt_coefficient, blob.crt_coefficient);
     }
@@ -495,27 +589,22 @@ mod test {
 
         let pub_exp: u64 = 65537;
 
-        let result = RsaKeyPair::set_key_pair(
-            &modulus,
-            &pub_exp.to_be_bytes(),
-            &p,
-            &q,
-            RsaKeyUsage::Sign,
-        );
+        let result =
+            RsaKeyPair::set_key_pair(&modulus, &pub_exp.to_be_bytes(), &p, &q, RsaKeyUsage::Sign);
         assert!(result.is_ok());
         let key_pair = result.unwrap();
-        assert_eq!(key_pair.key_usage(), RsaKeyUsage::Sign);
-        assert_eq!(key_pair.size_of_primes(), (128,128));
-        assert_eq!(key_pair.size_of_modulus(), 256);
+        assert_eq!(key_pair.get_key_usage(), RsaKeyUsage::Sign);
+        assert_eq!(key_pair.size_of_primes(), (128, 128));
+        assert_eq!(key_pair.get_size_of_modulus(), 256);
         assert_eq!(key_pair.size_of_public_exponent(), 3);
-        let key_blob = key_pair.export_key_pair_blob().unwrap(); 
+        let key_blob = key_pair.export_key_pair_blob().unwrap();
         assert_eq!(key_blob.modulus, modulus.to_vec());
         assert_eq!(key_blob.p, p);
         assert_eq!(key_blob.q, q);
     }
 
     #[test]
-    fn test_set_and_get_public_key() { 
+    fn test_set_and_get_public_key() {
         let modulus = [
             215, 145, 16, 194, 78, 246, 213, 23, 173, 178, 123, 179, 152, 238, 67, 16, 25, 20, 102,
             36, 142, 210, 5, 164, 214, 122, 56, 206, 61, 65, 121, 44, 248, 241, 176, 72, 104, 251,
@@ -533,13 +622,101 @@ mod test {
             17, 124, 191, 60, 163, 218, 149, 209, 207, 181,
         ];
         let pub_exp: u64 = 65537;
-        let result = RsaPublicKey::set_public_key(&modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
+        let result =
+            RsaPublicKey::set_public_key(&modulus, &pub_exp.to_be_bytes(), RsaKeyUsage::Encrypt);
 
         assert!(result.is_ok());
         let pub_key = result.unwrap();
 
-        assert_eq!(pub_key.key_usage(), RsaKeyUsage::Encrypt);
-        assert_eq!(pub_key.size_of_modulus(), 256);
+        assert_eq!(pub_key.get_key_usage(), RsaKeyUsage::Encrypt);
+        assert_eq!(pub_key.get_size_of_modulus(), 256);
         assert_eq!(pub_key.size_of_public_exponent(), 3);
+    }
+
+    /// new
+    #[test]
+    fn test_export_public_key_blob_on_key_pair() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Encrypt).unwrap();
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+
+        assert_eq!(
+            public_key_blob.modulus.len(),
+            key_pair.get_size_of_modulus() as usize
+        );
+        assert_eq!(
+            public_key_blob.pub_exp.len(),
+            key_pair.size_of_public_exponent() as usize
+        );
+    }
+
+    #[test]
+    fn test_set_invalid_key_pair() {
+        let invalid_modulus = vec![0u8; 256]; // Invalid modulus
+        let invalid_pub_exp = vec![0u8; 3]; // Invalid public exponent
+        let invalid_prime = vec![0u8; 128]; // Invalid prime p
+        let invalid_prime_q = vec![0u8; 128]; // Invalid prime q
+
+        let result = RsaKeyPair::set_key_pair(
+            &invalid_modulus,
+            &invalid_pub_exp,
+            &invalid_prime,
+            &invalid_prime_q,
+            RsaKeyUsage::SignAndEncrypt,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_invalid_public_key() {
+        let invalid_modulus = vec![0u8; 256]; // Invalid modulus
+        let invalid_pub_exp = vec![0u8; 3]; // Invalid public exponent
+
+        let result =
+            RsaPublicKey::set_public_key(&invalid_modulus, &invalid_pub_exp, RsaKeyUsage::Encrypt);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_key_usage_conversion() {
+        let key_usage_sign = RsaKeyUsage::Sign;
+        let key_usage_encrypt = RsaKeyUsage::Encrypt;
+        let key_usage_both = RsaKeyUsage::SignAndEncrypt;
+
+        assert_eq!(
+            key_usage_sign.to_symcrypt_flag(),
+            symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN
+        );
+        assert_eq!(
+            key_usage_encrypt.to_symcrypt_flag(),
+            symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT
+        );
+        assert_eq!(
+            key_usage_both.to_symcrypt_flag(),
+            symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT | symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN
+        );
+    }
+
+    #[test]
+    fn test_generate_with_boundary_key_sizes() {
+        let result = RsaKeyPair::generate_new(512, None, RsaKeyUsage::Sign).unwrap_err();
+        assert_eq!(result, SymCryptError::InvalidArgument);
+
+        let result = RsaKeyPair::generate_new(4096, None, RsaKeyUsage::Sign);
+        assert!(result.is_ok());
+        let key_pair_4096 = result.unwrap();
+        assert_eq!(key_pair_4096.get_size_of_modulus(), 4096 / 8);
+    }
+
+    #[test]
+    fn test_key_deletion() {
+        {
+            let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Encrypt).unwrap();
+            let public_key_blob = key_pair.export_public_key_blob().unwrap();
+            assert_eq!(
+                public_key_blob.modulus.len(),
+                key_pair.get_size_of_modulus() as usize
+            );
+        } // Key pair should be dropped here
+          // If no memory leaks or segmentation faults occur, the test passes.
     }
 }

--- a/rust-symcrypt/src/rsa/oaep.rs
+++ b/rust-symcrypt/src/rsa/oaep.rs
@@ -1,0 +1,252 @@
+//! OAEP functions for [`RsaKeyPair`] and [`RsaPublicKey`]. For more info please refer to symcrypt.h
+//!
+//! Decrypt functionality is locked to only be usable by [`RsaKeyPair`].
+//! Encrypt functionality is provided by both [`RsaKeyPair`] and [`RsaPublicKey`].
+//!
+//! #Example
+//!
+//! ## Encrypt and Decrypt with [`RsaKeyPair`].
+//! ```rust
+//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::hash::HashAlgorithm;
+//!
+//! // Generate a new RSA key pair
+//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+//!
+//! // Set up message to encrypt
+//! let message = b"example message";
+//! let hash_algorithm = HashAlgorithm::Sha256;
+//! let label = b"label";
+//!
+//! // Encrypt the message
+//! let encrypted_message = key_pair.oaep_encrypt(message, hash_algorithm, label).unwrap();
+//!
+//! // Decrypt the message and verify it matches the original message
+//! let decrypted_message = key_pair.oaep_decrypt(&encrypted_message, hash_algorithm, label).unwrap();
+//! assert_eq!(decrypted_message, message);
+//! ```
+//!
+use crate::errors::SymCryptError;
+use crate::hash::HashAlgorithm;
+use crate::rsa::{RsaKeyPair, RsaPublicKey};
+use crate::NumberFormat;
+
+impl RsaKeyPair {
+    /// `oaep_decrypt()` is only available for [`RsaKeyPair`].
+    ///
+    /// This function returns a decrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `encrypted_message` is a `&[u8]` that represents the message to decrypt.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm to use.
+    ///
+    /// `label` is a `&[u8]` that represents the label to use.
+    pub fn oaep_decrypt(
+        &self,
+        encrypted_message: &[u8],
+        hash_algorithm: HashAlgorithm,
+        label: &[u8],
+    ) -> Result<Vec<u8>, SymCryptError> {
+        let mut result_size: symcrypt_sys::SIZE_T = 0;
+        let modulus_size = self.get_size_of_modulus();
+        let mut decrypted_buffer = vec![0u8; modulus_size as usize];
+        let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+
+        unsafe {
+            // SAFETY: FFI calls
+            let error_code = symcrypt_sys::SymCryptRsaOaepDecrypt(
+                self.inner(),
+                encrypted_message.as_ptr(),
+                encrypted_message.len() as symcrypt_sys::SIZE_T,
+                NumberFormat::MSB.to_symcrypt_format(),
+                hash_algorithm_ptr,
+                label.as_ptr(),
+                label.len() as symcrypt_sys::SIZE_T,
+                0, // flags must be 0
+                decrypted_buffer.as_mut_ptr(),
+                modulus_size as symcrypt_sys::SIZE_T,
+                &mut result_size,
+            );
+
+            if error_code == symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR {
+                // SymCrypt fills the buffer with info and returns the size of the decrypted data in result_size
+                // for the caller to decide if they wish to truncate the buffer to the actual size of the decrypted data.
+                // Max size for the buffer is the size of the modulus.
+                decrypted_buffer.truncate(result_size as usize);
+                Ok(decrypted_buffer)
+            } else {
+                Err(error_code.into())
+            }
+        }
+    }
+
+    /// `oaep_encrypt()` returns a encrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `message` is a `&[u8]` that represents the message to encrypt.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm to use.
+    ///
+    /// `label` is a `&[u8]` that represents the label to use.
+    pub fn oaep_encrypt(
+        &self,
+        message: &[u8],
+        hash_algorithm: HashAlgorithm,
+        label: &[u8],
+    ) -> Result<Vec<u8>, SymCryptError> {
+        oaep_encrypt_helper(
+            self.inner(),
+            self.get_size_of_modulus(),
+            message,
+            hash_algorithm,
+            label,
+        )
+    }
+}
+
+impl RsaPublicKey {
+    /// `oaep_encrypt()` returns a encrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `message` is a `&[u8]` that represents the message to encrypt.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm to use.
+    ///
+    /// `label` is a `&[u8]` that represents the label to use.
+    pub fn oaep_encrypt(
+        &self,
+        message: &[u8],
+        hash_algorithm: HashAlgorithm,
+        label: &[u8],
+    ) -> Result<Vec<u8>, SymCryptError> {
+        oaep_encrypt_helper(
+            self.inner(),
+            self.get_size_of_modulus(),
+            message,
+            hash_algorithm,
+            label,
+        )
+    }
+}
+
+// private helper functions for oaep encrypt. The underlying call to SymCrypt is the same since SymCrypt does not make any distinction between public / key pair.
+fn oaep_encrypt_helper(
+    symcrypt_key: symcrypt_sys::PSYMCRYPT_RSAKEY,
+    modulus_size: u32,
+    message: &[u8],
+    hash_algorithm: HashAlgorithm,
+    label: &[u8],
+) -> Result<Vec<u8>, SymCryptError> {
+    let mut result_size: symcrypt_sys::SIZE_T = 0;
+    let mut encrypted = vec![0u8; modulus_size as usize];
+    let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+
+    unsafe {
+        // SAFETY: FFI calls
+        let error_code = symcrypt_sys::SymCryptRsaOaepEncrypt(
+            symcrypt_key,
+            message.as_ptr(),
+            message.len() as symcrypt_sys::SIZE_T,
+            hash_algorithm_ptr,
+            label.as_ptr(),
+            label.len() as symcrypt_sys::SIZE_T,
+            0, // flags must be 0
+            NumberFormat::MSB.to_symcrypt_format(),
+            encrypted.as_mut_ptr(),
+            modulus_size as symcrypt_sys::SIZE_T,
+            &mut result_size,
+        );
+
+        if error_code == symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR {
+            Ok(encrypted)
+        } else {
+            Err(error_code.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::SymCryptError;
+    use crate::hash::{sha256, HashAlgorithm};
+    use crate::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
+
+    #[test]
+    fn test_oaep_encrypt_decrypt() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let message = b"example message";
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let label = b"label";
+
+        let encrypted_message = key_pair
+            .oaep_encrypt(message, hash_algorithm, label)
+            .unwrap();
+        let decrypted_message = key_pair
+            .oaep_decrypt(&encrypted_message, hash_algorithm, label)
+            .unwrap();
+
+        assert_eq!(decrypted_message, message);
+    }
+
+    #[test]
+    fn test_oaep_encrypt_with_public_key() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaPublicKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::Encrypt,
+        )
+        .unwrap();
+
+        // Message to encrypt
+        let message = b"example message";
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let label = b"label";
+
+        let encrypted_message = public_key
+            .oaep_encrypt(message, hash_algorithm, label)
+            .unwrap();
+
+        let decrypted_message = key_pair
+            .oaep_decrypt(&encrypted_message, hash_algorithm, label)
+            .unwrap();
+
+        assert_eq!(decrypted_message, message);
+    }
+
+    #[test]
+    fn test_oaep_encrypt_decrypt_with_empty_label() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        // Message to encrypt
+        let message = b"example message";
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let label = b"";
+
+        let encrypted_message = key_pair
+            .oaep_encrypt(message, hash_algorithm, label)
+            .unwrap();
+        let decrypted_message = key_pair
+            .oaep_decrypt(&encrypted_message, hash_algorithm, label)
+            .unwrap();
+
+        assert_eq!(decrypted_message, message);
+    }
+
+    #[test]
+    fn test_oaep_encrypt_decrypt_large_message() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let encrypted_message = [0u8; 1000];
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let label = b"";
+
+        let decrypted_message = key_pair
+            .oaep_decrypt(&encrypted_message, hash_algorithm, label)
+            .unwrap_err();
+
+        assert_eq!(decrypted_message, SymCryptError::InvalidArgument);
+    }
+}

--- a/rust-symcrypt/src/rsa/oaep.rs
+++ b/rust-symcrypt/src/rsa/oaep.rs
@@ -76,7 +76,7 @@ impl RsaKey {
         }
     }
 
-    /// `oaep_encrypt()` returns a encrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
+    /// `oaep_encrypt()` returns an encrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
     ///
     /// `message` is a `&[u8]` that represents the message to encrypt.
     ///

--- a/rust-symcrypt/src/rsa/oaep.rs
+++ b/rust-symcrypt/src/rsa/oaep.rs
@@ -1,17 +1,14 @@
-//! OAEP functions for [`RsaKeyPair`] and [`RsaPublicKey`]. For more info please refer to symcrypt.h
-//!
-//! Decrypt functionality is locked to only be usable by [`RsaKeyPair`].
-//! Encrypt functionality is provided by both [`RsaKeyPair`] and [`RsaPublicKey`].
+//! OAEP functions for [`RsaKey`]. For more info please refer to symcrypt.h
 //!
 //! #Example
 //!
-//! ## Encrypt and Decrypt with [`RsaKeyPair`].
+//! ## Encrypt and Decrypt with [`RsaKey`].
 //! ```rust
-//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::rsa::{RsaKey, RsaKeyUsage};
 //! use symcrypt::hash::HashAlgorithm;
 //!
 //! // Generate a new RSA key pair
-//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+//! let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 //!
 //! // Set up message to encrypt
 //! let message = b"example message";
@@ -28,19 +25,19 @@
 //!
 use crate::errors::SymCryptError;
 use crate::hash::HashAlgorithm;
-use crate::rsa::{RsaKeyPair, RsaPublicKey};
+use crate::rsa::RsaKey;
 use crate::NumberFormat;
 
-impl RsaKeyPair {
-    /// `oaep_decrypt()` is only available for [`RsaKeyPair`].
-    ///
-    /// This function returns a decrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
+impl RsaKey {
+    /// `oaep_decrypt()` returns a decrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
     ///
     /// `encrypted_message` is a `&[u8]` that represents the message to decrypt.
     ///
     /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm to use.
     ///
     /// `label` is a `&[u8]` that represents the label to use.
+    ///
+    /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
     pub fn oaep_decrypt(
         &self,
         encrypted_message: &[u8],
@@ -92,69 +89,29 @@ impl RsaKeyPair {
         hash_algorithm: HashAlgorithm,
         label: &[u8],
     ) -> Result<Vec<u8>, SymCryptError> {
-        oaep_encrypt_helper(
-            self.inner(),
-            self.get_size_of_modulus(),
-            message,
-            hash_algorithm,
-            label,
-        )
-    }
-}
+        let mut result_size: symcrypt_sys::SIZE_T = 0;
+        let modulus_size = self.get_size_of_modulus();
+        let mut encrypted = vec![0u8; modulus_size as usize];
+        let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
 
-impl RsaPublicKey {
-    /// `oaep_encrypt()` returns a encrypted message as a `Vec<u8>`, or a [`SymCryptError`] if the operation fails.
-    ///
-    /// `message` is a `&[u8]` that represents the message to encrypt.
-    ///
-    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm to use.
-    ///
-    /// `label` is a `&[u8]` that represents the label to use.
-    pub fn oaep_encrypt(
-        &self,
-        message: &[u8],
-        hash_algorithm: HashAlgorithm,
-        label: &[u8],
-    ) -> Result<Vec<u8>, SymCryptError> {
-        oaep_encrypt_helper(
-            self.inner(),
-            self.get_size_of_modulus(),
-            message,
-            hash_algorithm,
-            label,
-        )
-    }
-}
-
-// private helper functions for oaep encrypt. The underlying call to SymCrypt is the same since SymCrypt does not make any distinction between public / key pair.
-fn oaep_encrypt_helper(
-    symcrypt_key: symcrypt_sys::PSYMCRYPT_RSAKEY,
-    modulus_size: u32,
-    message: &[u8],
-    hash_algorithm: HashAlgorithm,
-    label: &[u8],
-) -> Result<Vec<u8>, SymCryptError> {
-    let mut result_size: symcrypt_sys::SIZE_T = 0;
-    let mut encrypted = vec![0u8; modulus_size as usize];
-    let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
-
-    unsafe {
-        // SAFETY: FFI calls
-        match symcrypt_sys::SymCryptRsaOaepEncrypt(
-            symcrypt_key,
-            message.as_ptr(),
-            message.len() as symcrypt_sys::SIZE_T,
-            hash_algorithm_ptr,
-            label.as_ptr(),
-            label.len() as symcrypt_sys::SIZE_T,
-            0, // flags must be 0
-            NumberFormat::MSB.to_symcrypt_format(),
-            encrypted.as_mut_ptr(),
-            modulus_size as symcrypt_sys::SIZE_T,
-            &mut result_size,
-        ) {
-            symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(encrypted),
-            err => Err(err.into()),
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptRsaOaepEncrypt(
+                self.inner(),
+                message.as_ptr(),
+                message.len() as symcrypt_sys::SIZE_T,
+                hash_algorithm_ptr,
+                label.as_ptr(),
+                label.len() as symcrypt_sys::SIZE_T,
+                0, // flags must be 0
+                NumberFormat::MSB.to_symcrypt_format(),
+                encrypted.as_mut_ptr(),
+                modulus_size as symcrypt_sys::SIZE_T,
+                &mut result_size,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(encrypted),
+                err => Err(err.into()),
+            }
         }
     }
 }
@@ -163,11 +120,11 @@ fn oaep_encrypt_helper(
 mod tests {
     use crate::errors::SymCryptError;
     use crate::hash::HashAlgorithm;
-    use crate::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
+    use crate::rsa::{RsaKey, RsaKeyUsage};
 
     #[test]
     fn test_oaep_encrypt_decrypt() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         let message = b"example message";
         let hash_algorithm = HashAlgorithm::Sha256;
@@ -185,10 +142,10 @@ mod tests {
 
     #[test]
     fn test_oaep_encrypt_with_public_key() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         let public_key_blob = key_pair.export_public_key_blob().unwrap();
-        let public_key = RsaPublicKey::set_public_key(
+        let public_key = RsaKey::set_public_key(
             &public_key_blob.modulus,
             &public_key_blob.pub_exp,
             RsaKeyUsage::Encrypt,
@@ -213,7 +170,7 @@ mod tests {
 
     #[test]
     fn test_oaep_encrypt_decrypt_with_empty_label() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         // Message to encrypt
         let message = b"example message";
@@ -232,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_oaep_encrypt_decrypt_large_message() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         let encrypted_message = [0u8; 1000];
         let hash_algorithm = HashAlgorithm::Sha256;
@@ -247,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_oaep_encrypt_with_wrong_key_usage() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Sign).unwrap();
 
         let message = b"example message";
         let hash_algorithm = HashAlgorithm::Sha256;
@@ -255,6 +212,24 @@ mod tests {
 
         let result = key_pair
             .oaep_encrypt(message, hash_algorithm, label)
+            .unwrap_err();
+        assert_eq!(result, SymCryptError::InvalidArgument);
+    }
+
+    #[test]
+    fn test_oaep_decrypt_with_public_key() {
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::Encrypt,
+        )
+        .unwrap();
+
+        let result = public_key
+            .oaep_decrypt(&[0u8; 1000], HashAlgorithm::Sha256, b"label")
             .unwrap_err();
         assert_eq!(result, SymCryptError::InvalidArgument);
     }

--- a/rust-symcrypt/src/rsa/oaep.rs
+++ b/rust-symcrypt/src/rsa/oaep.rs
@@ -165,9 +165,8 @@ fn oaep_encrypt_helper(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::errors::SymCryptError;
-    use crate::hash::{sha256, HashAlgorithm};
+    use crate::hash::HashAlgorithm;
     use crate::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
 
     #[test]

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -1,18 +1,15 @@
-//! PKCS1 functions for [`RsaKeyPair`] and [`RsaPublicKey`]. For more info please refer to symcrypt.h
-//!
-//! Sign and Decrypt functionality are locked to only be usable from [`RsaKeyPair`], while
-//! Verify and Encrypt functionality are usable from both [`RsaKeyPair`] and [`RsaPublicKey`].
+//! PKCS1 functions for [`RsaKey`]. For more info please refer to symcrypt.h
 //!
 //! # Examples
 //!
-//! ## Sign and Verify using RsaKeyPair and RsaPublicKey
+//! ## Sign and Verify using RsaKey
 //!
 //! ```rust
-//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
+//! use symcrypt::rsa::{RsaKey, RsaKeyUsage};
 //! use symcrypt::hash::{sha256, HashAlgorithm};
 //!
 //! // Generate key pair.
-//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+//! let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 //!
 //! // Set up message.
 //! let hashed_message = sha256(b"hello world");
@@ -23,20 +20,20 @@
 //!
 //! // Create Public Key to verify signature.
 //! let public_key_blob = key_pair.export_public_key_blob().unwrap();
-//! let public_key = RsaPublicKey::set_public_key(&public_key_blob.modulus, &public_key_blob.pub_exp, RsaKeyUsage::SignAndEncrypt).unwrap();
+//! let public_key = RsaKey::set_public_key(&public_key_blob.modulus, &public_key_blob.pub_exp, RsaKeyUsage::SignAndEncrypt).unwrap();
 //!
 //! // Verify signature.
 //! let verify_result = public_key.pkcs1_verify(&hashed_message, &signature, hash_algorithm);
 //! assert!(verify_result.is_ok());
 //! ```
 //!
-//! ## Encrypt and Decrypt using RsaKeyPair
+//! ## Encrypt and Decrypt using RsaKey
 //!
 //! ```rust
-//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::rsa::{RsaKey, RsaKeyUsage};
 //!
 //! // Generate key pair.
-//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+//! let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 //!
 //! // Set up message.
 //! let message = b"example message";
@@ -51,19 +48,19 @@
 //!
 use crate::errors::SymCryptError;
 use crate::hash::HashAlgorithm;
-use crate::rsa::{RsaKeyPair, RsaPublicKey};
+use crate::rsa::RsaKey;
 use crate::NumberFormat;
 
-/// Impl for Pkcs1 RSA via [`RsaKeyPair`]
-impl RsaKeyPair {
-    /// `pcks1_sign()` is only available for [`RsaKeyPair`].
-    ///
-    /// This function signs a hashed message using the private key of the key pair and returns a `Vec<u8>` representing the signature,
+/// Impl for Pkcs1 RSA via [`RsaKey`]
+impl RsaKey {
+    /// `pcks1_sign()` signs a hashed message using the private key of [`RsaKey`] and returns a `Vec<u8>` representing the signature,
     /// or a [`SymCryptError`] if the operation fails.
     ///
     /// `hashed_message` is a `&[u8]` representing the hashed message to be signed.
     ///
     /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
+    ///
+    /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
     pub fn pkcs1_sign(
         &self,
         hashed_message: &[u8],
@@ -93,12 +90,12 @@ impl RsaKeyPair {
         }
     }
 
-    /// `pcks1_decrypt()` is only available for [`RsaKeyPair`].
-    ///
-    /// This function decrypts an encrypted buffer using the private key of the key pair and returns a `Vec<u8>` representing the decrypted buffer,
+    /// `pcks1_decrypt()` decrypts an encrypted buffer using the private key of [`RsaKey`] and returns a `Vec<u8>` representing the decrypted buffer,
     /// or a [`SymCryptError`] if the operation fails.
     ///
     /// `encrypted_buffer` is a `&[u8]` representing the encrypted buffer to be decrypted.
+    ///
+    /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
     pub fn pkcs1_decrypt(&self, encrypted_buffer: &[u8]) -> Result<Vec<u8>, SymCryptError> {
         let mut result_size = 0;
         let modulus_size = self.get_size_of_modulus();
@@ -142,95 +139,49 @@ impl RsaKeyPair {
         signature: &[u8],
         hash_algorithm: HashAlgorithm,
     ) -> Result<(), SymCryptError> {
-        pkcs1_verify_helper(self.inner(), hashed_message, signature, hash_algorithm)
-    }
-
-    /// `pkcs1_encrypt()` encrypts a buffer using the public key of the key pair and returns a `Vec<u8>` representing the encrypted buffer,
-    /// or a [`SymCryptError`] if the operation fails.
-    ///
-    /// `buffer` is a `&[u8]` representing the buffer to be encrypted.
-    pub fn pkcs1_encrypt(&self, message: &[u8]) -> Result<Vec<u8>, SymCryptError> {
-        pkcs1_encrypt_helper(self.inner(), message, self.get_size_of_modulus())
-    }
-}
-
-impl RsaPublicKey {
-    /// `pkcs1_verify()` returns a [`SymCryptError`] if the signature verification fails and `Ok(())` if the verification is successful.
-    ///
-    /// Caller must check the return value to determine if the signature is valid before continuing.
-    ///
-    /// `hashed_message` is a `&[u8]` representing the hashed message to be verified.
-    ///
-    /// `signature` is a `&[u8]` representing the signature to be verified.
-    ///
-    /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
-    pub fn pkcs1_verify(
-        &self,
-        hashed_message: &[u8],
-        signature: &[u8],
-        hash_algorithm: HashAlgorithm,
-    ) -> Result<(), SymCryptError> {
-        pkcs1_verify_helper(self.inner(), hashed_message, signature, hash_algorithm)
-    }
-
-    /// `pkcs1_encrypt()` encrypts a buffer using the public key of the key pair and returns a `Vec<u8>` representing the encrypted buffer,
-    /// or a [`SymCryptError`] if the operation fails.
-    ///
-    /// `buffer` is a `&[u8]` representing the buffer to be encrypted.
-    pub fn pkcs1_encrypt(&self, message: &[u8]) -> Result<Vec<u8>, SymCryptError> {
-        pkcs1_encrypt_helper(self.inner(), message, self.get_size_of_modulus())
-    }
-}
-
-// private helper functions for pcks1 encryption. The underlying call to SymCrypt is the same since SymCrypt does not make any distinction between public / key pair.
-fn pkcs1_encrypt_helper(
-    symcrypt_key: symcrypt_sys::PSYMCRYPT_RSAKEY,
-    buffer: &[u8],
-    size_of_modulus: u32,
-) -> Result<Vec<u8>, SymCryptError> {
-    let mut result_size = 0;
-    let mut encrypted_buffer = vec![0u8; size_of_modulus as usize];
-    unsafe {
-        // SAFETY: FFI calls
-        match symcrypt_sys::SymCryptRsaPkcs1Encrypt(
-            symcrypt_key,
-            buffer.as_ptr(),
-            buffer.len() as symcrypt_sys::SIZE_T,
-            0, // No flags can be set
-            NumberFormat::MSB.to_symcrypt_format(),
-            encrypted_buffer.as_mut_ptr(),
-            size_of_modulus as symcrypt_sys::SIZE_T,
-            &mut result_size,
-        ) {
-            symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(encrypted_buffer),
-            err => Err(err.into()),
+        let converted_hash_oids = hash_algorithm.to_oid_list();
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptRsaPkcs1Verify(
+                self.inner(),
+                hashed_message.as_ptr(),
+                hashed_message.len() as symcrypt_sys::SIZE_T,
+                signature.as_ptr(),
+                signature.len() as symcrypt_sys::SIZE_T,
+                NumberFormat::MSB.to_symcrypt_format(), // Only MSB is supported
+                converted_hash_oids.as_ptr(),
+                converted_hash_oids.len() as symcrypt_sys::SIZE_T,
+                0,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+                err => Err(err.into()),
+            }
         }
     }
-}
 
-// private helper functions for pcks1 verify. The underlying call to SymCrypt is the same since SymCrypt does not make any distinction between public / key pair.
-fn pkcs1_verify_helper(
-    symcrypt_key: symcrypt_sys::PSYMCRYPT_RSAKEY,
-    hashed_value: &[u8],
-    signature: &[u8],
-    hash_algorithm: HashAlgorithm,
-) -> Result<(), SymCryptError> {
-    let converted_hash_oids = hash_algorithm.to_oid_list();
-    unsafe {
-        // SAFETY: FFI calls
-        match symcrypt_sys::SymCryptRsaPkcs1Verify(
-            symcrypt_key,
-            hashed_value.as_ptr(),
-            hashed_value.len() as symcrypt_sys::SIZE_T,
-            signature.as_ptr(),
-            signature.len() as symcrypt_sys::SIZE_T,
-            NumberFormat::MSB.to_symcrypt_format(), // Only MSB is supported
-            converted_hash_oids.as_ptr(),
-            converted_hash_oids.len() as symcrypt_sys::SIZE_T,
-            0,
-        ) {
-            symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
-            err => Err(err.into()),
+    /// `pkcs1_encrypt()` encrypts a message using the public key of the key pair and returns a `Vec<u8>` representing the encrypted message,
+    /// or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `message` is a `&[u8]` representing the buffer to be encrypted.
+    pub fn pkcs1_encrypt(&self, message: &[u8]) -> Result<Vec<u8>, SymCryptError> {
+        let mut result_size = 0;
+        let size_of_modulus = self.get_size_of_modulus();
+        let mut encrypted_buffer = vec![0u8; size_of_modulus as usize];
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptRsaPkcs1Encrypt(
+                self.inner(),
+                message.as_ptr(),
+                message.len() as symcrypt_sys::SIZE_T,
+                0, // No flags can be set
+                NumberFormat::MSB.to_symcrypt_format(),
+                encrypted_buffer.as_mut_ptr(),
+                size_of_modulus as symcrypt_sys::SIZE_T,
+                &mut result_size,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(encrypted_buffer),
+                err => Err(err.into()),
+            }
         }
     }
 }
@@ -239,14 +190,14 @@ fn pkcs1_verify_helper(
 mod tests {
     use super::*;
     use crate::hash::{sha256, HashAlgorithm};
-    use crate::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
+    use crate::rsa::{RsaKey, RsaKeyUsage};
 
     #[test]
     fn test_pkcs1_sign_verify() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         let public_key_blob = key_pair.export_public_key_blob().unwrap();
-        let public_key = RsaPublicKey::set_public_key(
+        let public_key = RsaKey::set_public_key(
             &public_key_blob.modulus,
             &public_key_blob.pub_exp,
             RsaKeyUsage::SignAndEncrypt,
@@ -266,7 +217,7 @@ mod tests {
 
     #[test]
     fn test_pkcs1_encrypt_decrypt() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
         let message = b"example message";
 
         let encrypted_message = key_pair.pkcs1_encrypt(message).unwrap();
@@ -277,11 +228,11 @@ mod tests {
 
     #[test]
     fn test_pkcs1_encrypt_with_public_key() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
         let message = b"example message";
 
         let public_key_blob = key_pair.export_public_key_blob().unwrap();
-        let public_key = RsaPublicKey::set_public_key(
+        let public_key = RsaKey::set_public_key(
             &public_key_blob.modulus,
             &public_key_blob.pub_exp,
             RsaKeyUsage::Encrypt,
@@ -297,10 +248,10 @@ mod tests {
     #[test]
     fn test_pkcs1_sign_verify_with_different_keys() {
         let signing_key_pair =
-            RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+            RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         let verifying_key_pair =
-            RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+            RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         let hashed_message = sha256(b"hello world");
         let hash_algorithm = HashAlgorithm::Sha256;
@@ -310,7 +261,7 @@ mod tests {
             .unwrap();
 
         let public_key_blob = verifying_key_pair.export_public_key_blob().unwrap();
-        let public_key = RsaPublicKey::set_public_key(
+        let public_key = RsaKey::set_public_key(
             &public_key_blob.modulus,
             &public_key_blob.pub_exp,
             RsaKeyUsage::SignAndEncrypt,
@@ -326,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_pkcs1_decrypt_with_invalid_data() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
         let message = b"example message";
 
@@ -342,7 +293,7 @@ mod tests {
 
     #[test]
     fn test_pkcs1_encrypt_with_wrong_key_usage() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Sign).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Sign).unwrap();
         let message = b"example message";
 
         let encrypt_result = key_pair.pkcs1_encrypt(message).unwrap_err();
@@ -351,7 +302,7 @@ mod tests {
 
     #[test]
     fn test_pkcs1_sign_with_wrong_key_usage() {
-        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::Encrypt).unwrap();
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::Encrypt).unwrap();
 
         let hashed_message = sha256(b"hello world");
         let hash_algorithm = HashAlgorithm::Sha256;
@@ -360,5 +311,45 @@ mod tests {
             .pkcs1_sign(&hashed_message, hash_algorithm)
             .unwrap_err();
         assert_eq!(sign_result, SymCryptError::InvalidArgument);
+    }
+
+    #[test]
+    fn test_pkcs1_decrypt_with_public_key() {
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let message = b"example message";
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::Encrypt,
+        )
+        .unwrap();
+
+        let encrypted_message = public_key.pkcs1_encrypt(message).unwrap();
+        let result = public_key.pkcs1_decrypt(&encrypted_message).unwrap_err();
+
+        assert_eq!(result, SymCryptError::InvalidArgument);
+    }
+
+    #[test]
+    fn test_pkcs1_sign_with_public_key() {
+        let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::Encrypt,
+        )
+        .unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+
+        let result = public_key
+            .pkcs1_sign(&hashed_message, hash_algorithm)
+            .unwrap_err();
+        assert_eq!(result, SymCryptError::InvalidArgument);
     }
 }

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -8,7 +8,7 @@
 //! ## Sign and Verify using RsaKeyPair and RsaPublicKey
 //!
 //! ```rust
-//! use symcrypt::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
 //! use symcrypt::hash::{sha256, HashAlgorithm};
 //!
 //! // Generate key pair.
@@ -33,7 +33,7 @@
 //! ## Encrypt and Decrypt using RsaKeyPair
 //!
 //! ```rust
-//! use symcrypt::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
 //!
 //! // Generate key pair.
 //! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -90,13 +90,13 @@ impl RsaKey {
         }
     }
 
-    /// `pcks1_decrypt()` decrypts an encrypted buffer using the private key of [`RsaKey`] and returns a `Vec<u8>` representing the decrypted buffer,
+    /// `pcks1_decrypt()` decrypts an encrypted message using the private key of [`RsaKey`] and returns a `Vec<u8>` representing the decrypted message,
     /// or a [`SymCryptError`] if the operation fails.
     ///
-    /// `encrypted_buffer` is a `&[u8]` representing the encrypted buffer to be decrypted.
+    /// `encrypted_message` is a `&[u8]` representing the encrypted message to be decrypted.
     ///
     /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
-    pub fn pkcs1_decrypt(&self, encrypted_buffer: &[u8]) -> Result<Vec<u8>, SymCryptError> {
+    pub fn pkcs1_decrypt(&self, encrypted_message: &[u8]) -> Result<Vec<u8>, SymCryptError> {
         let mut result_size = 0;
         let modulus_size = self.get_size_of_modulus();
         let mut decrypted_buffer = vec![0u8; modulus_size as usize]; // Max size will be the size of the modulus.
@@ -104,8 +104,8 @@ impl RsaKey {
             // SAFETY: FFI calls
             match symcrypt_sys::SymCryptRsaPkcs1Decrypt(
                 self.inner(),
-                encrypted_buffer.as_ptr(),
-                encrypted_buffer.len() as symcrypt_sys::SIZE_T,
+                encrypted_message.as_ptr(),
+                encrypted_message.len() as symcrypt_sys::SIZE_T,
                 NumberFormat::MSB.to_symcrypt_format(),
                 0, // No flags can be set
                 decrypted_buffer.as_mut_ptr(),
@@ -162,7 +162,7 @@ impl RsaKey {
     /// `pkcs1_encrypt()` encrypts a message using the public key of the key pair and returns a `Vec<u8>` representing the encrypted message,
     /// or a [`SymCryptError`] if the operation fails.
     ///
-    /// `message` is a `&[u8]` representing the buffer to be encrypted.
+    /// `message` is a `&[u8]` representing the message to be encrypted.
     pub fn pkcs1_encrypt(&self, message: &[u8]) -> Result<Vec<u8>, SymCryptError> {
         let mut result_size = 0;
         let size_of_modulus = self.get_size_of_modulus();

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -1,0 +1,348 @@
+//! PKCS1 functions for [`RsaKeyPair`] and [`RsaPublicKey`]. For more info please refer to symcrypt.h
+//!
+//! Sign and Decrypt functionality are locked to only be usable from [`RsaKeyPair`], while
+//! Verify and Encrypt functionality are usable from both [`RsaKeyPair`] and [`RsaPublicKey`].
+//!
+//! # Examples
+//!
+//! ## Sign and Verify using RsaKeyPair and RsaPublicKey
+//!
+//! ```rust
+//! use symcrypt::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::hash::{sha256, HashAlgorithm};
+//!
+//! // Generate key pair.
+//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+//!
+//! // Set up message.
+//! let hashed_message = sha256(b"hello world");
+//! let hash_algorithm = HashAlgorithm::Sha256;
+//!
+//! // Create signature.
+//! let signature = key_pair.pkcs1_sign(&hashed_message, hash_algorithm).unwrap();
+//!
+//! // Create Public Key to verify signature.
+//! let public_key_blob = key_pair.export_public_key_blob().unwrap();
+//! let public_key = RsaPublicKey::set_public_key(&public_key_blob.modulus, &public_key_blob.pub_exp, RsaKeyUsage::SignAndEncrypt).unwrap();
+//!
+//! // Verify signature.
+//! let verify_result = public_key.pkcs1_verify(&hashed_message, &signature, hash_algorithm);
+//! assert!(verify_result.is_ok());
+//! ```
+//!
+//! ## Encrypt and Decrypt using RsaKeyPair
+//!
+//! ```rust
+//! use symcrypt::{RsaKeyPair, RsaKeyUsage};
+//!
+//! // Generate key pair.
+//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+//!
+//! // Set up message.
+//! let message = b"example message";
+//!
+//! // Encrypt message.
+//! let encrypted_message = key_pair.pkcs1_encrypt(message).unwrap();
+//!
+//! // Decrypt message.
+//! let decrypted_message = key_pair.pkcs1_decrypt(&encrypted_message).unwrap();
+//! assert_eq!(decrypted_message, message);
+//! ```
+//!
+use crate::errors::SymCryptError;
+use crate::hash::HashAlgorithm;
+use crate::rsa::{RsaKeyPair, RsaPublicKey};
+use crate::NumberFormat;
+
+/// Impl for Pkcs1 RSA via [`RsaKeyPair`]
+impl RsaKeyPair {
+    /// `pcks1_sign()` is only available for [`RsaKeyPair`].
+    ///
+    /// This function signs a hashed message using the private key of the key pair and returns a `Vec<u8>` representing the signature,
+    /// or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `hashed_message` is a `&[u8]` representing the hashed message to be signed.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
+    pub fn pkcs1_sign(
+        &self,
+        hashed_message: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<Vec<u8>, SymCryptError> {
+        let mut result_size = 0;
+        let modulus_size = self.get_size_of_modulus();
+        let mut signature = vec![0u8; modulus_size as usize];
+        let converted_hash_oids = hash_algorithm.to_oid_list();
+        unsafe {
+            // SAFETY: FFI calls
+            let error_code = symcrypt_sys::SymCryptRsaPkcs1Sign(
+                self.inner(),
+                hashed_message.as_ptr(),
+                hashed_message.len() as symcrypt_sys::SIZE_T,
+                converted_hash_oids.as_ptr(),
+                converted_hash_oids.len() as symcrypt_sys::SIZE_T,
+                symcrypt_sys::SYMCRYPT_FLAG_RSA_PKCS1_NO_ASN1,
+                NumberFormat::MSB.to_symcrypt_format(),
+                signature.as_mut_ptr(),
+                modulus_size as symcrypt_sys::SIZE_T,
+                &mut result_size,
+            );
+            if error_code == symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR {
+                if (modulus_size as symcrypt_sys::SIZE_T) < result_size {
+                    return Err(SymCryptError::MemoryAllocationFailure);
+                }
+                signature.truncate(result_size as usize);
+                Ok(signature)
+            } else {
+                Err(error_code.into())
+            }
+        }
+    }
+
+    /// `pcks1_decrypt()` is only available for [`RsaKeyPair`].
+    ///
+    /// This function decrypts an encrypted buffer using the private key of the key pair and returns a `Vec<u8>` representing the decrypted buffer,
+    /// or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `encrypted_buffer` is a `&[u8]` representing the encrypted buffer to be decrypted.
+    pub fn pkcs1_decrypt(&self, encrypted_buffer: &[u8]) -> Result<Vec<u8>, SymCryptError> {
+        let mut result_size = 0;
+        let modulus_size = self.get_size_of_modulus();
+        let mut decrypted_buffer = vec![0u8; modulus_size as usize]; // Max size will be the size of the modulus.
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptRsaPkcs1Decrypt(
+                self.inner(),
+                encrypted_buffer.as_ptr(),
+                encrypted_buffer.len() as symcrypt_sys::SIZE_T,
+                NumberFormat::MSB.to_symcrypt_format(),
+                0, // No flags can be set
+                decrypted_buffer.as_mut_ptr(),
+                modulus_size as symcrypt_sys::SIZE_T,
+                &mut result_size,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => {
+                    // SymCrypt fills the buffer with info and returns the size of the signature in result_size
+                    // for the caller to decide if they wish to truncate the buffer to the actual size of the signature.
+                    // Max size for the buffer is the size of the modulus.
+                    decrypted_buffer.truncate(result_size as usize);
+                    Ok(decrypted_buffer)
+                }
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// `pkcs1_verify()` returns a [`SymCryptError`] if the signature verification fails and `Ok(())` if the verification is successful.
+    ///
+    /// Caller must check the return value to determine if the signature is valid before continuing.
+    ///
+    /// `hashed_message` is a `&[u8]` representing the hashed message to be verified.
+    ///
+    /// `signature` is a `&[u8]` representing the signature to be verified.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
+    pub fn pkcs1_verify(
+        &self,
+        hashed_message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<(), SymCryptError> {
+        pkcs1_verify_helper(self.inner(), hashed_message, signature, hash_algorithm)
+    }
+
+    /// `pkcs1_encrypt()` encrypts a buffer using the public key of the key pair and returns a `Vec<u8>` representing the encrypted buffer,
+    /// or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `buffer` is a `&[u8]` representing the buffer to be encrypted.
+    pub fn pkcs1_encrypt(&self, message: &[u8]) -> Result<Vec<u8>, SymCryptError> {
+        pkcs1_encrypt_helper(self.inner(), message, self.get_size_of_modulus())
+    }
+}
+
+impl RsaPublicKey {
+    /// `pkcs1_verify()` returns a [`SymCryptError`] if the signature verification fails and `Ok(())` if the verification is successful.
+    ///
+    /// Caller must check the return value to determine if the signature is valid before continuing.
+    ///
+    /// `hashed_message` is a `&[u8]` representing the hashed message to be verified.
+    ///
+    /// `signature` is a `&[u8]` representing the signature to be verified.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
+    pub fn pkcs1_verify(
+        &self,
+        hashed_message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+    ) -> Result<(), SymCryptError> {
+        pkcs1_verify_helper(self.inner(), hashed_message, signature, hash_algorithm)
+    }
+
+    /// `pkcs1_encrypt()` encrypts a buffer using the public key of the key pair and returns a `Vec<u8>` representing the encrypted buffer,
+    /// or a [`SymCryptError`] if the operation fails.
+    ///
+    /// `buffer` is a `&[u8]` representing the buffer to be encrypted.
+    pub fn pkcs1_encrypt(&self, message: &[u8]) -> Result<Vec<u8>, SymCryptError> {
+        pkcs1_encrypt_helper(self.inner(), message, self.get_size_of_modulus())
+    }
+}
+
+// private helper functions for pcks1 encryption. The underlying call to SymCrypt is the same since SymCrypt does not make any distinction between public / key pair.
+fn pkcs1_encrypt_helper(
+    symcrypt_key: symcrypt_sys::PSYMCRYPT_RSAKEY,
+    buffer: &[u8],
+    size_of_modulus: u32,
+) -> Result<Vec<u8>, SymCryptError> {
+    let mut result_size = 0;
+    let mut encrypted_buffer = vec![0u8; size_of_modulus as usize];
+    unsafe {
+        // SAFETY: FFI calls
+        match symcrypt_sys::SymCryptRsaPkcs1Encrypt(
+            symcrypt_key,
+            buffer.as_ptr(),
+            buffer.len() as symcrypt_sys::SIZE_T,
+            0, // No flags can be set
+            NumberFormat::MSB.to_symcrypt_format(),
+            encrypted_buffer.as_mut_ptr(),
+            size_of_modulus as symcrypt_sys::SIZE_T,
+            &mut result_size,
+        ) {
+            symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(encrypted_buffer),
+            err => Err(err.into()),
+        }
+    }
+}
+
+// private helper functions for pcks1 verify. The underlying call to SymCrypt is the same since SymCrypt does not make any distinction between public / key pair.
+fn pkcs1_verify_helper(
+    symcrypt_key: symcrypt_sys::PSYMCRYPT_RSAKEY,
+    hashed_value: &[u8],
+    signature: &[u8],
+    hash_algorithm: HashAlgorithm,
+) -> Result<(), SymCryptError> {
+    let converted_hash_oids = hash_algorithm.to_oid_list();
+    unsafe {
+        // SAFETY: FFI calls
+        match symcrypt_sys::SymCryptRsaPkcs1Verify(
+            symcrypt_key,
+            hashed_value.as_ptr(),
+            hashed_value.len() as symcrypt_sys::SIZE_T,
+            signature.as_ptr(),
+            signature.len() as symcrypt_sys::SIZE_T,
+            NumberFormat::MSB.to_symcrypt_format(), // Only MSB is supported
+            converted_hash_oids.as_ptr(),
+            converted_hash_oids.len() as symcrypt_sys::SIZE_T,
+            symcrypt_sys::SYMCRYPT_FLAG_RSA_PKCS1_OPTIONAL_HASH_OID,
+        ) {
+            symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+            err => Err(err.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::{sha256, HashAlgorithm};
+    use crate::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
+
+    #[test]
+    fn test_pkcs1_sign_verify() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaPublicKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::SignAndEncrypt,
+        )
+        .unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+
+        let signature = key_pair
+            .pkcs1_sign(&hashed_message, hash_algorithm)
+            .unwrap();
+        let verify_result = public_key.pkcs1_verify(&hashed_message, &signature, hash_algorithm);
+
+        assert!(verify_result.is_ok());
+    }
+
+    #[test]
+    fn test_pkcs1_encrypt_decrypt() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let message = b"example message";
+
+        let encrypted_message = key_pair.pkcs1_encrypt(message).unwrap();
+        let decrypted_message = key_pair.pkcs1_decrypt(&encrypted_message).unwrap();
+
+        assert_eq!(decrypted_message, message);
+    }
+
+    #[test]
+    fn test_pkcs1_encrypt_with_public_key() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let message = b"example message";
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaPublicKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::Encrypt,
+        )
+        .unwrap();
+
+        let encrypted_message = public_key.pkcs1_encrypt(message).unwrap();
+        let decrypted_message = key_pair.pkcs1_decrypt(&encrypted_message).unwrap();
+
+        assert_eq!(decrypted_message, message);
+    }
+
+    #[test]
+    fn test_pkcs1_sign_verify_with_different_keys() {
+        let signing_key_pair =
+            RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let verifying_key_pair =
+            RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+
+        let signature = signing_key_pair
+            .pkcs1_sign(&hashed_message, hash_algorithm)
+            .unwrap();
+
+        let public_key_blob = verifying_key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaPublicKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::SignAndEncrypt,
+        )
+        .unwrap();
+
+        let verify_result = public_key
+            .pkcs1_verify(&hashed_message, &signature, hash_algorithm)
+            .unwrap_err();
+
+        assert_eq!(verify_result, SymCryptError::SignatureVerificationFailure);
+    }
+
+    #[test]
+    fn test_pkcs1_decrypt_with_invalid_data() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let message = b"example message";
+
+        let encrypted_message = key_pair.pkcs1_encrypt(message).unwrap();
+
+        let mut invalid_encrypted_message = encrypted_message.clone();
+        invalid_encrypted_message[0] ^= 0xFF;
+
+        let decrypt_result = key_pair.pkcs1_decrypt(&invalid_encrypted_message);
+
+        assert!(decrypt_result.is_err());
+    }
+}

--- a/rust-symcrypt/src/rsa/pss.rs
+++ b/rust-symcrypt/src/rsa/pss.rs
@@ -1,0 +1,293 @@
+//! PSS functions for [`RsaKeyPair`] and [`RsaPublicKey`]. For more info please refer to symcrypt.h
+//!
+//! Signing functionality is locked to only be usable by [`RsaKeyPair`].
+//! Verification functionality is provided by both [`RsaKeyPair`] and [`RsaPublicKey`].
+//!
+//! # Example
+//!
+//! ## Sign and Verify with [`RsaKeyPair`]
+//!
+//! ```rust
+//! use symcrypt::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::hash::{sha256, HashAlgorithm};
+//!
+//! // Generate key pair
+//! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+//!
+//! // Set up message
+//! let hashed_message = sha256(b"hello world");
+//! let hash_algorithm = HashAlgorithm::Sha256;
+//! let salt_length = 32;
+//!
+//! // Create and verify the signature
+//! let signature = key_pair.pss_sign(&hashed_message, hash_algorithm, salt_length).unwrap();
+//! let verify_result = key_pair.pss_verify(&hashed_message, &signature, hash_algorithm, salt_length);
+//!
+//! assert!(verify_result.is_ok());
+//! ```
+//!
+use crate::errors::SymCryptError;
+use crate::hash::HashAlgorithm;
+use crate::rsa::{RsaKeyPair, RsaPublicKey};
+use crate::NumberFormat;
+use symcrypt_sys::PSYMCRYPT_RSAKEY;
+
+impl RsaKeyPair {
+    /// `pss_sign` is only available for [`RsaKeyPair`].
+    ///
+    /// This function returns a `Vec<u8>` that represents the signature of the hashed message, or a [`SymCryptError`] if the operation failed.
+    ///
+    /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
+    ///  
+    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm used to hash the message.
+    ///
+    /// `salt_length` is a `usize` that represents the length of the salt to be used in the PSS signature, this value is typically the length of the hash output.
+    pub fn pss_sign(
+        &self,
+        hashed_message: &[u8],
+        hash_algorithm: HashAlgorithm,
+        salt_length: usize,
+    ) -> Result<Vec<u8>, SymCryptError> {
+        let mut result_size = 0;
+        let modulus_size = self.get_size_of_modulus();
+        let mut signature = vec![0u8; modulus_size as usize];
+        let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+
+        unsafe {
+            // SAFETY: FFI calls
+            let error_code = symcrypt_sys::SymCryptRsaPssSign(
+                self.inner(),
+                hashed_message.as_ptr(),
+                hashed_message.len() as symcrypt_sys::SIZE_T,
+                hash_algorithm_ptr,
+                salt_length as symcrypt_sys::SIZE_T,
+                0, // flags must be 0
+                NumberFormat::MSB.to_symcrypt_format(),
+                signature.as_mut_ptr(),
+                modulus_size as symcrypt_sys::SIZE_T,
+                &mut result_size,
+            );
+
+            if error_code == symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR {
+                // SymCrypt fills the buffer with info and returns the size of the signature in result_size
+                // for the caller to decide if they wish to truncate the buffer to the actual size of the signature.
+                // Max size for the buffer is the size of the modulus.
+                signature.truncate(result_size as usize);
+                Ok(signature)
+            } else {
+                Err(error_code.into())
+            }
+        }
+    }
+
+    /// `pss_verify` returns a [`SymCryptError`] if the signature verification fails and `Ok(())` if the verification is successful.
+    ///
+    /// Caller must check the return value to determine if the signature is valid before continuing.
+    ///
+    /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
+    ///  
+    /// `signature` is a `&[u8]` that represents the signature of the hashed message.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm used to hash the message.
+    ///
+    /// `salt_length` is a `usize` that represents the length of the salt to be used in the PSS signature, this value is typically the length of the hash output.
+    pub fn pss_verify(
+        &self,
+        hashed_message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+        salt_length: usize,
+    ) -> Result<(), SymCryptError> {
+        pss_verify_helper(
+            self.inner(),
+            hashed_message,
+            signature,
+            hash_algorithm,
+            salt_length,
+        )
+    }
+}
+
+impl RsaPublicKey {
+    /// `pss_verify` returns a [`SymCryptError`] if the signature verification fails and `Ok(())` if the verification is successful.
+    ///
+    /// Caller must check the return value to determine if the signature is valid before continuing.
+    ///
+    /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
+    ///  
+    /// `signature` is a `&[u8]` that represents the signature of the hashed message.
+    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm used to hash the message.
+    ///
+    /// `salt_length` is a `usize` that represents the length of the salt to be used in the PSS signature, this value is typically the length of the hash output.
+    pub fn pss_verify(
+        &self,
+        hashed_message: &[u8],
+        signature: &[u8],
+        hash_algorithm: HashAlgorithm,
+        salt_length: usize,
+    ) -> Result<(), SymCryptError> {
+        pss_verify_helper(
+            self.inner(),
+            hashed_message,
+            signature,
+            hash_algorithm,
+            salt_length,
+        )
+    }
+}
+
+// private helper functions for pss verify. The underlying call to SymCrypt is the same since SymCrypt does not make any distinction between public / key pair.
+fn pss_verify_helper(
+    symcrypt_key: PSYMCRYPT_RSAKEY,
+    hashed_message: &[u8],
+    signature: &[u8],
+    hash_algorithm: HashAlgorithm,
+    salt_length: usize,
+) -> Result<(), SymCryptError> {
+    let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+
+    unsafe {
+        // SAFETY: FFI calls
+        match symcrypt_sys::SymCryptRsaPssVerify(
+            symcrypt_key,
+            hashed_message.as_ptr(),
+            hashed_message.len() as symcrypt_sys::SIZE_T,
+            signature.as_ptr(),
+            signature.len() as symcrypt_sys::SIZE_T,
+            NumberFormat::MSB.to_symcrypt_format(),
+            hash_algorithm_ptr,
+            salt_length as symcrypt_sys::SIZE_T,
+            0, // flags must be 0
+        ) {
+            symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(()),
+            err => Err(err.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::hash::{sha256, sha384, HashAlgorithm};
+    use crate::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
+    use crate::NumberFormat;
+
+    #[test]
+    fn test_pss_sign_and_verify_with_key_pair() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let salt_length = 32;
+
+        let signature = key_pair
+            .pss_sign(&hashed_message, hash_algorithm, salt_length)
+            .unwrap();
+
+        let verify_result =
+            key_pair.pss_verify(&hashed_message, &signature, hash_algorithm, salt_length);
+
+        assert!(verify_result.is_ok());
+    }
+    #[test]
+    fn test_pss_sign_and_verify_with_public_key_bytes() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaPublicKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::SignAndEncrypt,
+        )
+        .unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let salt_length = 32;
+
+        let signature = key_pair
+            .pss_sign(&hashed_message, hash_algorithm, salt_length)
+            .unwrap();
+
+        let verify_result =
+            public_key.pss_verify(&hashed_message, &signature, hash_algorithm, salt_length);
+
+        assert!(verify_result.is_ok());
+    }
+
+    #[test]
+    fn test_pss_sign_and_verify_with_different_key() {
+        let key_pair_1 = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+        let key_pair_2 = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let salt_length = 32;
+
+        let signature = key_pair_1
+            .pss_sign(&hashed_message, hash_algorithm, salt_length)
+            .unwrap();
+
+        let verify_result = key_pair_2
+            .pss_verify(&hashed_message, &signature, hash_algorithm, salt_length)
+            .unwrap_err();
+
+        assert_eq!(verify_result, SymCryptError::SignatureVerificationFailure);
+    }
+
+    #[test]
+    fn test_pss_sign_and_verify_tampered_signature() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaPublicKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::SignAndEncrypt,
+        )
+        .unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let salt_length = 32;
+
+        let mut signature = key_pair
+            .pss_sign(&hashed_message, hash_algorithm, salt_length)
+            .unwrap();
+
+        // tamper with signature
+        signature[0] = 0xFF;
+
+        let verify_result = public_key
+            .pss_verify(&hashed_message, &signature, hash_algorithm, salt_length)
+            .unwrap_err();
+
+        assert_eq!(verify_result, SymCryptError::InvalidArgument);
+    }
+
+    #[test]
+    fn test_pss_sign_and_verify_salt_too_large() {
+        let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
+
+        let public_key_blob = key_pair.export_public_key_blob().unwrap();
+        let public_key = RsaPublicKey::set_public_key(
+            &public_key_blob.modulus,
+            &public_key_blob.pub_exp,
+            RsaKeyUsage::SignAndEncrypt,
+        )
+        .unwrap();
+
+        let hashed_message = sha256(b"hello world");
+        let hash_algorithm = HashAlgorithm::Sha256;
+
+        // If the length of the hash + the size of the salt is larger than the size of the modulus, then generation should fail
+        let salt_length = 1000;
+
+        let mut signature = key_pair
+            .pss_sign(&hashed_message, hash_algorithm, salt_length)
+            .unwrap_err();
+
+        assert_eq!(signature, SymCryptError::InvalidArgument);
+    }
+}

--- a/rust-symcrypt/src/rsa/pss.rs
+++ b/rust-symcrypt/src/rsa/pss.rs
@@ -166,9 +166,8 @@ fn pss_verify_helper(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::hash::{sha256, sha384, HashAlgorithm};
+    use crate::hash::{sha256, HashAlgorithm};
     use crate::rsa::{RsaKeyPair, RsaKeyUsage, RsaPublicKey};
-    use crate::NumberFormat;
 
     #[test]
     fn test_pss_sign_and_verify_with_key_pair() {
@@ -267,21 +266,13 @@ mod test {
     fn test_pss_sign_and_verify_salt_too_large() {
         let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 
-        let public_key_blob = key_pair.export_public_key_blob().unwrap();
-        let public_key = RsaPublicKey::set_public_key(
-            &public_key_blob.modulus,
-            &public_key_blob.pub_exp,
-            RsaKeyUsage::SignAndEncrypt,
-        )
-        .unwrap();
-
         let hashed_message = sha256(b"hello world");
         let hash_algorithm = HashAlgorithm::Sha256;
 
         // If the length of the hash + the size of the salt is larger than the size of the modulus, then generation should fail
         let salt_length = 1000;
 
-        let mut signature = key_pair
+        let signature = key_pair
             .pss_sign(&hashed_message, hash_algorithm, salt_length)
             .unwrap_err();
 

--- a/rust-symcrypt/src/rsa/pss.rs
+++ b/rust-symcrypt/src/rsa/pss.rs
@@ -8,7 +8,7 @@
 //! ## Sign and Verify with [`RsaKeyPair`]
 //!
 //! ```rust
-//! use symcrypt::{RsaKeyPair, RsaKeyUsage};
+//! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
 //! use symcrypt::hash::{sha256, HashAlgorithm};
 //!
 //! // Generate key pair

--- a/rust-symcrypt/src/rsa/pss.rs
+++ b/rust-symcrypt/src/rsa/pss.rs
@@ -9,7 +9,7 @@
 //!
 //! ```rust
 //! use symcrypt::rsa::{RsaKeyPair, RsaKeyUsage};
-//! use symcrypt::hash::{sha256, HashAlgorithm};
+//! use symcrypt::hash::{sha256, HashAlgorithm, SHA256_RESULT_SIZE};
 //!
 //! // Generate key pair
 //! let key_pair = RsaKeyPair::generate_new(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
@@ -17,7 +17,7 @@
 //! // Set up message
 //! let hashed_message = sha256(b"hello world");
 //! let hash_algorithm = HashAlgorithm::Sha256;
-//! let salt_length = 32;
+//! let salt_length = SHA256_RESULT_SIZE; // 32 bytes for SHA256
 //!
 //! // Create and verify the signature
 //! let signature = key_pair.pss_sign(&hashed_message, hash_algorithm, salt_length).unwrap();
@@ -69,10 +69,7 @@ impl RsaKeyPair {
             );
 
             if error_code == symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR {
-                // SymCrypt fills the buffer with info and returns the size of the signature in result_size
-                // for the caller to decide if they wish to truncate the buffer to the actual size of the signature.
-                // Max size for the buffer is the size of the modulus.
-                signature.truncate(result_size as usize);
+                // For signing the size of the output will always be the size of the modulus with the current padding modes.
                 Ok(signature)
             } else {
                 Err(error_code.into())

--- a/symcrypt-bindgen/build.rs
+++ b/symcrypt-bindgen/build.rs
@@ -40,10 +40,17 @@ fn main() {
         .allowlist_var("^SymCryptEcurveParams(NistP256|NistP384|Curve25519)$")
         .allowlist_function("^(SymCryptEckey(Allocate|Free|SizeofPublicKey|GetValue|SetRandom|SetValue|SetRandom|))$")
         .allowlist_var("SYMCRYPT_FLAG_ECKEY_ECDH")
+        .allowlist_var("SYMCRYPT_FLAG_ECKEY_ECDSA")
         .allowlist_function("SymCryptEcDhSecretAgreement")
         // RSA FUNCTIONS
-        .allowlist_function("^(SymCryptRsakey.*)$")
-        .allowlist_function("^(SymCryptRsaRaw.*)$")
+        .allowlist_function("^SymCryptRsa.*") // Must allow ALL SymCryptRsakey* before blocking the functions that are not needed.
+        .blocklist_function("SymCryptRsakeyCreate")
+        .blocklist_function("SymCryptRsakeySizeofRsakeyFromParams")
+        .blocklist_function("SymCryptRsakeyWipe")
+        .blocklist_function("SymCryptRsaSelftest")
+        .blocklist_function("^SymCryptRsaRaw.*$")
+        .allowlist_var("SYMCRYPT_FLAG_RSAKEY_ENCRYPT")
+        .allowlist_var("SYMCRYPT_FLAG_RSAKEY_SIGN")
         // ECDSA functions
         .allowlist_function("^(SymCryptEcDsa(Sign|Verify).*)")
         // RSA PKCS1 FUNCTIONS

--- a/symcrypt-bindgen/build.rs
+++ b/symcrypt-bindgen/build.rs
@@ -26,6 +26,7 @@ fn main() {
         // HASH FUNCTIONS
         .allowlist_function("^SymCrypt(?:Sha(?:256|384|512|1)|Md5)(?:Init|Append|Result|StateCopy)?$")
         .allowlist_var("^(SYMCRYPT_(SHA256|SHA384|SHA512|SHA1|MD5)_RESULT_SIZE$)")
+        .allowlist_var("^SymCrypt(?:Sha3_(?:256|384|512)|Sha(?:256|384|512|1)|Md5)Algorithm$")
         // HMAC FUNCTIONS
         .allowlist_function("^SymCryptHmac(?:Sha(?:256|384|512|1)|Md5)(?:ExpandKey|Init|Append|Result|StateCopy)?$")
         // GCM FUNCTIONS
@@ -55,8 +56,12 @@ fn main() {
         .allowlist_function("^(SymCryptEcDsa(Sign|Verify).*)")
         // RSA PKCS1 FUNCTIONS
         .allowlist_function("^(SymCryptRsaPkcs1(Sign|Verify|Encrypt|Decrypt).*)$")
+        .allowlist_var("SYMCRYPT_FLAG_RSA_PKCS1_NO_ASN1")
+        .allowlist_var("SYMCRYPT_FLAG_RSA_PKCS1_OPTIONAL_HASH_OID")
         // RSA PSS FUNCTIONS
         .allowlist_function("^(SymCryptRsaPss(Sign|Verify).*)$")
+        // OID LISTS
+        .allowlist_var("^SymCrypt(Sha(1|256|384|512|3_(256|384|512))|Md5)OidList$")
         // UTILITY FUNCTIONS
         .allowlist_function("SymCryptWipe")
         .allowlist_function("SymCryptRandom")

--- a/symcrypt-bindgen/build.rs
+++ b/symcrypt-bindgen/build.rs
@@ -24,8 +24,8 @@ fn main() {
         .allowlist_function("SymCryptModuleInit")
         .allowlist_var("^(SYMCRYPT_CODE_VERSION.*)$")
         // HASH FUNCTIONS
-        .allowlist_function("^SymCrypt(?:Sha(?:256|384|512|1)|Md5)(?:Init|Append|Result|StateCopy)?$")
-        .allowlist_var("^(SYMCRYPT_(SHA256|SHA384|SHA512|SHA1|MD5)_RESULT_SIZE$)")
+        .allowlist_function("^SymCrypt(?:Sha3_(?:256|384|512)|Sha(?:256|384|512|1)|Md5)(?:Init|Append|Result|StateCopy)?$")
+        .allowlist_var("^(SYMCRYPT_(SHA3_256|SHA3_384|SHA3_512|SHA256|SHA384|SHA512|SHA1|MD5)_RESULT_SIZE$)")
         .allowlist_var("^SymCrypt(?:Sha3_(?:256|384|512)|Sha(?:256|384|512|1)|Md5)Algorithm$")
         // HMAC FUNCTIONS
         .allowlist_function("^SymCryptHmac(?:Sha(?:256|384|512|1)|Md5)(?:ExpandKey|Init|Append|Result|StateCopy)?$")

--- a/symcrypt-bindgen/build.rs
+++ b/symcrypt-bindgen/build.rs
@@ -60,6 +60,8 @@ fn main() {
         // UTILITY FUNCTIONS
         .allowlist_function("SymCryptWipe")
         .allowlist_function("SymCryptRandom")
+        .allowlist_function("SymCryptLoadMsbFirstUint64")
+        .allowlist_function("SymCryptStoreMsbFirstUint64")    
         
         .generate_comments(true)
         .derive_default(true)

--- a/symcrypt-sys/src/symcrypt_bindings.rs
+++ b/symcrypt-sys/src/symcrypt_bindings.rs
@@ -8,6 +8,9 @@ pub const SYMCRYPT_SHA1_RESULT_SIZE: u32 = 20;
 pub const SYMCRYPT_SHA256_RESULT_SIZE: u32 = 32;
 pub const SYMCRYPT_SHA384_RESULT_SIZE: u32 = 48;
 pub const SYMCRYPT_SHA512_RESULT_SIZE: u32 = 64;
+pub const SYMCRYPT_SHA3_256_RESULT_SIZE: u32 = 32;
+pub const SYMCRYPT_SHA3_384_RESULT_SIZE: u32 = 48;
+pub const SYMCRYPT_SHA3_512_RESULT_SIZE: u32 = 64;
 pub const SYMCRYPT_FLAG_ECKEY_ECDSA: u32 = 4096;
 pub const SYMCRYPT_FLAG_ECKEY_ECDH: u32 = 8192;
 pub const SYMCRYPT_FLAG_RSAKEY_SIGN: u32 = 4096;
@@ -42,6 +45,7 @@ pub const _SYMCRYPT_ECURVE_TYPE_SYMCRYPT_ECURVE_TYPE_TWISTED_EDWARDS: _SYMCRYPT_
 pub const _SYMCRYPT_ECURVE_TYPE_SYMCRYPT_ECURVE_TYPE_MONTGOMERY: _SYMCRYPT_ECURVE_TYPE = 3;
 pub type _SYMCRYPT_ECURVE_TYPE = ::std::os::raw::c_int;
 pub use self::_SYMCRYPT_ECURVE_TYPE as SYMCRYPT_ECURVE_TYPE;
+pub type UINT8 = ::std::os::raw::c_uchar;
 pub type BYTE = ::std::os::raw::c_uchar;
 pub type UINT32 = ::std::os::raw::c_uint;
 pub type UINT64 = ::std::os::raw::c_ulonglong;
@@ -49,7 +53,6 @@ pub type ULONG_PTR = ::std::os::raw::c_ulonglong;
 pub type SIZE_T = ULONG_PTR;
 pub type PBYTE = *mut BYTE;
 pub type PCBYTE = *const BYTE;
-pub type PUINT32 = *mut UINT32;
 pub type PCUINT32 = *const UINT32;
 pub type PUINT64 = *mut UINT64;
 pub type PCUINT64 = *const UINT64;
@@ -800,6 +803,109 @@ impl Default for _SYMCRYPT_SHA384_STATE {
 pub type SYMCRYPT_SHA384_STATE = _SYMCRYPT_SHA384_STATE;
 pub type PSYMCRYPT_SHA384_STATE = *mut _SYMCRYPT_SHA384_STATE;
 pub type PCSYMCRYPT_SHA384_STATE = *const SYMCRYPT_SHA384_STATE;
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct _SYMCRYPT_KECCAK_STATE {
+    pub inputBlockSize: UINT32,
+    pub stateIndex: UINT32,
+    pub __bindgen_padding_0: u64,
+    pub state: [UINT64; 25usize],
+    pub magic: SIZE_T,
+    pub paddingValue: UINT8,
+    pub squeezeMode: BOOLEAN,
+}
+#[test]
+fn bindgen_test_layout__SYMCRYPT_KECCAK_STATE() {
+    const UNINIT: ::std::mem::MaybeUninit<_SYMCRYPT_KECCAK_STATE> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<_SYMCRYPT_KECCAK_STATE>(),
+        240usize,
+        concat!("Size of: ", stringify!(_SYMCRYPT_KECCAK_STATE))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<_SYMCRYPT_KECCAK_STATE>(),
+        16usize,
+        concat!("Alignment of ", stringify!(_SYMCRYPT_KECCAK_STATE))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).inputBlockSize) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SYMCRYPT_KECCAK_STATE),
+            "::",
+            stringify!(inputBlockSize)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).stateIndex) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SYMCRYPT_KECCAK_STATE),
+            "::",
+            stringify!(stateIndex)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).state) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+extern "C" {
+    pub fn SymCryptSha3_256StateCopy(
+        pSrc: PCSYMCRYPT_SHA3_256_STATE,
+        pDst: PSYMCRYPT_SHA3_256_STATE,
+    );
+}            stringify!(_SYMCRYPT_KECCAK_STATE),
+            "::",
+            stringify!(state)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).magic) as usize - ptr as usize },
+        216usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SYMCRYPT_KECCAK_STATE),
+            "::",
+            stringify!(magic)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).paddingValue) as usize - ptr as usize },
+        224usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SYMCRYPT_KECCAK_STATE),
+            "::",
+            stringify!(paddingValue)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).squeezeMode) as usize - ptr as usize },
+        225usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_SYMCRYPT_KECCAK_STATE),
+            "::",
+            stringify!(squeezeMode)
+        )
+    );
+}
+pub type SYMCRYPT_KECCAK_STATE = _SYMCRYPT_KECCAK_STATE;
+pub type SYMCRYPT_SHA3_256_STATE = SYMCRYPT_KECCAK_STATE;
+pub type PSYMCRYPT_SHA3_256_STATE = *mut SYMCRYPT_KECCAK_STATE;
+pub type PCSYMCRYPT_SHA3_256_STATE = *const SYMCRYPT_SHA3_256_STATE;
+pub type SYMCRYPT_SHA3_384_STATE = SYMCRYPT_KECCAK_STATE;
+pub type PSYMCRYPT_SHA3_384_STATE = *mut SYMCRYPT_KECCAK_STATE;
+pub type PCSYMCRYPT_SHA3_384_STATE = *const SYMCRYPT_SHA3_384_STATE;
+pub type SYMCRYPT_SHA3_512_STATE = SYMCRYPT_KECCAK_STATE;
+pub type PSYMCRYPT_SHA3_512_STATE = *mut SYMCRYPT_KECCAK_STATE;
+pub type PCSYMCRYPT_SHA3_512_STATE = *const SYMCRYPT_SHA3_512_STATE;
 pub type SYMCRYPT_HASH = _SYMCRYPT_HASH;
 pub type PCSYMCRYPT_HASH = *const SYMCRYPT_HASH;
 pub type PSYMCRYPT_HASH_INIT_FUNC = ::std::option::Option<unsafe extern "C" fn(pState: PVOID)>;
@@ -4389,20 +4495,56 @@ extern "C" {
 #[cfg(target_os = "windows")]
 #[link(name = "symcrypt", kind = "dylib")]
 extern "C" {
-    pub static SymCryptSha3_256Algorithm: PCSYMCRYPT_HASH;
+    pub static SymCryptSha512Algorithm: PCSYMCRYPT_HASH;
 }
 #[cfg(target_os = "linux")]
 extern "C" {
-    pub static SymCryptSha3_256Algorithm: PCSYMCRYPT_HASH;
+    pub static SymCryptSha512Algorithm: PCSYMCRYPT_HASH;
+}
+extern "C" {
+    pub fn SymCryptSha3_256(pbData: PCBYTE, cbData: SIZE_T, pbResult: PBYTE);
+}
+extern "C" {
+    pub fn SymCryptSha3_256Init(pState: PSYMCRYPT_SHA3_256_STATE);
+}
+extern "C" {
+    pub fn SymCryptSha3_256Append(pState: PSYMCRYPT_SHA3_256_STATE, pbData: PCBYTE, cbData: SIZE_T);
+}
+extern "C" {
+    pub fn SymCryptSha3_256Result(pState: PSYMCRYPT_SHA3_256_STATE, pbResult: PBYTE);
+}
+extern "C" {
+    pub fn SymCryptSha3_256StateCopy(
+        pSrc: PCSYMCRYPT_SHA3_256_STATE,
+        pDst: PSYMCRYPT_SHA3_256_STATE,
+    );
 }
 #[cfg(target_os = "windows")]
 #[link(name = "symcrypt", kind = "dylib")]
 extern "C" {
-    pub static SymCryptSha512Algorithm: PCSYMCRYPT_HASH;
+    pub static SymCryptSha3_256Algorithm: PCSYMCRYPT_HASH;
 }
 #[cfg(target_os = "linux")]
 extern "C" {
-    pub static SymCryptSha512Algorithm: PCSYMCRYPT_HASH;
+    pub static SymCryptSha3_256Algorithm: PCSYMCRYPT_HASH;
+}
+extern "C" {
+    pub fn SymCryptSha3_384(pbData: PCBYTE, cbData: SIZE_T, pbResult: PBYTE);
+}
+extern "C" {
+    pub fn SymCryptSha3_384Init(pState: PSYMCRYPT_SHA3_384_STATE);
+}
+extern "C" {
+    pub fn SymCryptSha3_384Append(pState: PSYMCRYPT_SHA3_384_STATE, pbData: PCBYTE, cbData: SIZE_T);
+}
+extern "C" {
+    pub fn SymCryptSha3_384Result(pState: PSYMCRYPT_SHA3_384_STATE, pbResult: PBYTE);
+}
+extern "C" {
+    pub fn SymCryptSha3_384StateCopy(
+        pSrc: PCSYMCRYPT_SHA3_384_STATE,
+        pDst: PSYMCRYPT_SHA3_384_STATE,
+    );
 }
 #[cfg(target_os = "windows")]
 #[link(name = "symcrypt", kind = "dylib")]
@@ -4412,6 +4554,24 @@ extern "C" {
 #[cfg(target_os = "linux")]
 extern "C" {
     pub static SymCryptSha3_384Algorithm: PCSYMCRYPT_HASH;
+}
+extern "C" {
+    pub fn SymCryptSha3_512(pbData: PCBYTE, cbData: SIZE_T, pbResult: PBYTE);
+}
+extern "C" {
+    pub fn SymCryptSha3_512Init(pState: PSYMCRYPT_SHA3_512_STATE);
+}
+extern "C" {
+    pub fn SymCryptSha3_512Append(pState: PSYMCRYPT_SHA3_512_STATE, pbData: PCBYTE, cbData: SIZE_T);
+}
+extern "C" {
+    pub fn SymCryptSha3_512Result(pState: PSYMCRYPT_SHA3_512_STATE, pbResult: PBYTE);
+}
+extern "C" {
+    pub fn SymCryptSha3_512StateCopy(
+        pSrc: PCSYMCRYPT_SHA3_512_STATE,
+        pDst: PSYMCRYPT_SHA3_512_STATE,
+    );
 }
 #[cfg(target_os = "windows")]
 #[link(name = "symcrypt", kind = "dylib")]
@@ -5174,7 +5334,6 @@ extern "C" {
         flags: UINT32,
     ) -> SYMCRYPT_ERROR;
 }
-
 extern "C" {
     pub fn SymCryptRsaPkcs1Encrypt(
         pkRsakey: PCSYMCRYPT_RSAKEY,

--- a/symcrypt-sys/src/symcrypt_bindings.rs
+++ b/symcrypt-sys/src/symcrypt_bindings.rs
@@ -855,12 +855,7 @@ fn bindgen_test_layout__SYMCRYPT_KECCAK_STATE() {
         16usize,
         concat!(
             "Offset of field: ",
-extern "C" {
-    pub fn SymCryptSha3_256StateCopy(
-        pSrc: PCSYMCRYPT_SHA3_256_STATE,
-        pDst: PSYMCRYPT_SHA3_256_STATE,
-    );
-}            stringify!(_SYMCRYPT_KECCAK_STATE),
+            stringify!(_SYMCRYPT_KECCAK_STATE),
             "::",
             stringify!(state)
         )

--- a/symcrypt-sys/src/symcrypt_bindings.rs
+++ b/symcrypt-sys/src/symcrypt_bindings.rs
@@ -47,6 +47,7 @@ pub type ULONG_PTR = ::std::os::raw::c_ulonglong;
 pub type SIZE_T = ULONG_PTR;
 pub type PBYTE = *mut BYTE;
 pub type PCBYTE = *const BYTE;
+pub type PUINT32 = *mut UINT32;
 pub type PCUINT32 = *const UINT32;
 pub type PUINT64 = *mut UINT64;
 pub type PCUINT64 = *const UINT64;
@@ -4258,6 +4259,16 @@ pub type PSYMCRYPT_ECKEY = *mut SYMCRYPT_ECKEY;
 pub type PCSYMCRYPT_ECKEY = *const SYMCRYPT_ECKEY;
 extern "C" {
     pub fn SymCryptWipe(pbData: PVOID, cbData: SIZE_T);
+}
+extern "C" {
+    pub fn SymCryptLoadMsbFirstUint64(
+        pbSrc: PCBYTE,
+        cbSrc: SIZE_T,
+        pDst: PUINT64,
+    ) -> SYMCRYPT_ERROR;
+}
+extern "C" {
+    pub fn SymCryptStoreMsbFirstUint64(src: UINT64, pbDst: PBYTE, cbDst: SIZE_T) -> SYMCRYPT_ERROR;
 }
 extern "C" {
     pub fn SymCryptModuleInit(api: UINT32, minor: UINT32);

--- a/symcrypt-sys/src/symcrypt_bindings.rs
+++ b/symcrypt-sys/src/symcrypt_bindings.rs
@@ -8,7 +8,10 @@ pub const SYMCRYPT_SHA1_RESULT_SIZE: u32 = 20;
 pub const SYMCRYPT_SHA256_RESULT_SIZE: u32 = 32;
 pub const SYMCRYPT_SHA384_RESULT_SIZE: u32 = 48;
 pub const SYMCRYPT_SHA512_RESULT_SIZE: u32 = 64;
+pub const SYMCRYPT_FLAG_ECKEY_ECDSA: u32 = 4096;
 pub const SYMCRYPT_FLAG_ECKEY_ECDH: u32 = 8192;
+pub const SYMCRYPT_FLAG_RSAKEY_SIGN: u32 = 4096;
+pub const SYMCRYPT_FLAG_RSAKEY_ENCRYPT: u32 = 8192;
 pub const SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR: SYMCRYPT_ERROR = 0;
 pub const SYMCRYPT_ERROR_SYMCRYPT_UNUSED: SYMCRYPT_ERROR = 32768;
 pub const SYMCRYPT_ERROR_SYMCRYPT_WRONG_KEY_SIZE: SYMCRYPT_ERROR = 32769;
@@ -4932,16 +4935,6 @@ extern "C" {
     pub fn SymCryptRsakeyFree(pkObj: PSYMCRYPT_RSAKEY);
 }
 extern "C" {
-    pub fn SymCryptRsakeyCreate(
-        pbBuffer: PBYTE,
-        cbBuffer: SIZE_T,
-        pParams: PCSYMCRYPT_RSA_PARAMS,
-    ) -> PSYMCRYPT_RSAKEY;
-}
-extern "C" {
-    pub fn SymCryptRsakeyWipe(pkDst: PSYMCRYPT_RSAKEY);
-}
-extern "C" {
     pub fn SymCryptEcurveAllocate(
         pParams: PCSYMCRYPT_ECURVE_PARAMS,
         flags: UINT32,
@@ -5096,29 +5089,7 @@ extern "C" {
         flags: UINT32,
     ) -> SYMCRYPT_ERROR;
 }
-extern "C" {
-    #[doc = " Crypto algorithm API *"]
-    pub fn SymCryptRsaRawEncrypt(
-        pkRsakey: PCSYMCRYPT_RSAKEY,
-        pbSrc: PCBYTE,
-        cbSrc: SIZE_T,
-        numFormat: SYMCRYPT_NUMBER_FORMAT,
-        flags: UINT32,
-        pbDst: PBYTE,
-        cbDst: SIZE_T,
-    ) -> SYMCRYPT_ERROR;
-}
-extern "C" {
-    pub fn SymCryptRsaRawDecrypt(
-        pkRsakey: PCSYMCRYPT_RSAKEY,
-        pbSrc: PCBYTE,
-        cbSrc: SIZE_T,
-        numFormat: SYMCRYPT_NUMBER_FORMAT,
-        flags: UINT32,
-        pbDst: PBYTE,
-        cbDst: SIZE_T,
-    ) -> SYMCRYPT_ERROR;
-}
+
 extern "C" {
     pub fn SymCryptRsaPkcs1Encrypt(
         pkRsakey: PCSYMCRYPT_RSAKEY,
@@ -5137,6 +5108,36 @@ extern "C" {
         pbSrc: PCBYTE,
         cbSrc: SIZE_T,
         nfSrc: SYMCRYPT_NUMBER_FORMAT,
+        flags: UINT32,
+        pbDst: PBYTE,
+        cbDst: SIZE_T,
+        pcbDst: *mut SIZE_T,
+    ) -> SYMCRYPT_ERROR;
+}
+extern "C" {
+    pub fn SymCryptRsaOaepEncrypt(
+        pkRsakey: PCSYMCRYPT_RSAKEY,
+        pbSrc: PCBYTE,
+        cbSrc: SIZE_T,
+        hashAlgorithm: PCSYMCRYPT_HASH,
+        pbLabel: PCBYTE,
+        cbLabel: SIZE_T,
+        flags: UINT32,
+        nfDst: SYMCRYPT_NUMBER_FORMAT,
+        pbDst: PBYTE,
+        cbDst: SIZE_T,
+        pcbDst: *mut SIZE_T,
+    ) -> SYMCRYPT_ERROR;
+}
+extern "C" {
+    pub fn SymCryptRsaOaepDecrypt(
+        pkRsakey: PCSYMCRYPT_RSAKEY,
+        pbSrc: PCBYTE,
+        cbSrc: SIZE_T,
+        nfSrc: SYMCRYPT_NUMBER_FORMAT,
+        hashAlgorithm: PCSYMCRYPT_HASH,
+        pbLabel: PCBYTE,
+        cbLabel: SIZE_T,
         flags: UINT32,
         pbDst: PBYTE,
         cbDst: SIZE_T,

--- a/symcrypt-sys/src/symcrypt_bindings.rs
+++ b/symcrypt-sys/src/symcrypt_bindings.rs
@@ -12,6 +12,8 @@ pub const SYMCRYPT_FLAG_ECKEY_ECDSA: u32 = 4096;
 pub const SYMCRYPT_FLAG_ECKEY_ECDH: u32 = 8192;
 pub const SYMCRYPT_FLAG_RSAKEY_SIGN: u32 = 4096;
 pub const SYMCRYPT_FLAG_RSAKEY_ENCRYPT: u32 = 8192;
+pub const SYMCRYPT_FLAG_RSA_PKCS1_NO_ASN1: u32 = 1;
+pub const SYMCRYPT_FLAG_RSA_PKCS1_OPTIONAL_HASH_OID: u32 = 2;
 pub const SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR: SYMCRYPT_ERROR = 0;
 pub const SYMCRYPT_ERROR_SYMCRYPT_UNUSED: SYMCRYPT_ERROR = 32768;
 pub const SYMCRYPT_ERROR_SYMCRYPT_WRONG_KEY_SIZE: SYMCRYPT_ERROR = 32769;
@@ -4288,6 +4290,15 @@ extern "C" {
 extern "C" {
     pub fn SymCryptMd5StateCopy(pSrc: PCSYMCRYPT_MD5_STATE, pDst: PSYMCRYPT_MD5_STATE);
 }
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptMd5Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptMd5Algorithm: PCSYMCRYPT_HASH;
+}
 extern "C" {
     pub fn SymCryptSha1(pbData: PCBYTE, cbData: SIZE_T, pbResult: PBYTE);
 }
@@ -4302,6 +4313,15 @@ extern "C" {
 }
 extern "C" {
     pub fn SymCryptSha1StateCopy(pSrc: PCSYMCRYPT_SHA1_STATE, pDst: PSYMCRYPT_SHA1_STATE);
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha1Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha1Algorithm: PCSYMCRYPT_HASH;
 }
 extern "C" {
     pub fn SymCryptSha256(pbData: PCBYTE, cbData: SIZE_T, pbResult: PBYTE);
@@ -4318,6 +4338,15 @@ extern "C" {
 extern "C" {
     pub fn SymCryptSha256StateCopy(pSrc: PCSYMCRYPT_SHA256_STATE, pDst: PSYMCRYPT_SHA256_STATE);
 }
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha256Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha256Algorithm: PCSYMCRYPT_HASH;
+}
 extern "C" {
     pub fn SymCryptSha384(pbData: PCBYTE, cbData: SIZE_T, pbResult: PBYTE);
 }
@@ -4333,6 +4362,15 @@ extern "C" {
 extern "C" {
     pub fn SymCryptSha384StateCopy(pSrc: PCSYMCRYPT_SHA384_STATE, pDst: PSYMCRYPT_SHA384_STATE);
 }
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha384Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha384Algorithm: PCSYMCRYPT_HASH;
+}
 extern "C" {
     pub fn SymCryptSha512(pbData: PCBYTE, cbData: SIZE_T, pbResult: PBYTE);
 }
@@ -4347,6 +4385,42 @@ extern "C" {
 }
 extern "C" {
     pub fn SymCryptSha512StateCopy(pSrc: PCSYMCRYPT_SHA512_STATE, pDst: PSYMCRYPT_SHA512_STATE);
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha3_256Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha3_256Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha512Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha512Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha3_384Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha3_384Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha3_512Algorithm: PCSYMCRYPT_HASH;
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha3_512Algorithm: PCSYMCRYPT_HASH;
 }
 extern "C" {
     pub fn SymCryptHmacMd5ExpandKey(
@@ -5207,6 +5281,78 @@ impl Default for _SYMCRYPT_OID {
 }
 pub type SYMCRYPT_OID = _SYMCRYPT_OID;
 pub type PCSYMCRYPT_OID = *const SYMCRYPT_OID;
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptMd5OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptMd5OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha1OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha1OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha256OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha256OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha384OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha384OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha512OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha512OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha3_256OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha3_256OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha3_384OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha3_384OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "windows")]
+#[link(name = "symcrypt", kind = "dylib")]
+extern "C" {
+    pub static SymCryptSha3_512OidList: [SYMCRYPT_OID; 2usize];
+}
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub static SymCryptSha3_512OidList: [SYMCRYPT_OID; 2usize];
+}
 extern "C" {
     pub fn SymCryptRsaPkcs1Sign(
         pkRsakey: PCSYMCRYPT_RSAKEY,


### PR DESCRIPTION
Changes added:
- Adding support for `RsaKey` 
- Adding `pss`, `oeap` and `pkcs1` related functions
- Adding hash oids required for rsa functionality 
