### PR TITLE
User/nnmkhang/hashing pin

### DIFF
--- a/rust-symcrypt/src/gcm.rs
+++ b/rust-symcrypt/src/gcm.rs
@@ -67,6 +67,7 @@ use core::ffi::c_void;
 use std::marker::PhantomPinned;
 use std::mem;
 use std::pin::Pin;
+use std::ptr;
 use symcrypt_sys;
 
 /// [`GcmExpandedKey`] is a struct that holds the Gcm expanded key from SymCrypt.
@@ -80,18 +81,6 @@ pub struct GcmExpandedKey {
     // doing so would lead to use-after-free and inconsistent states.
     expanded_key: Pin<Box<GcmInnerKey>>,
     key_length: usize,
-}
-
-impl Drop for GcmExpandedKey {
-    fn drop(&mut self) {
-        unsafe {
-            // SAFETY: FFI calls
-            symcrypt_sys::SymCryptWipe(
-                self.expanded_key.as_mut().get_inner_mut() as *mut c_void,
-                mem::size_of_val(&*self.expanded_key.as_ref().get_inner()) as symcrypt_sys::SIZE_T,
-            );
-        }
-    }
 }
 
 /// [`GcmInnerKey`] is a struct that holds the underlying SymCrypt state for GCM.
@@ -127,6 +116,18 @@ impl GcmInnerKey {
     // Safe method to access the inner state immutably
     pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_GCM_EXPANDED_KEY {
         &self.inner as *const _
+    }
+}
+
+impl Drop for GcmInnerKey {
+    fn drop(&mut self) {
+        unsafe {
+            // SAFETY: FFI calls
+            symcrypt_sys::SymCryptWipe(
+                ptr::addr_of_mut!(self.inner) as *mut c_void, // Using addr_of_mut! so we don't access in the inner field
+                mem::size_of_val(&self.inner) as symcrypt_sys::SIZE_T, // Using size_of_val! so we don't access in the inner field
+            );
+        }
     }
 }
 

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -376,7 +376,7 @@ pub fn sha1(data: &[u8]) -> [u8; SHA1_RESULT_SIZE] {
 // pub struct Sha256State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA256_STATE>>);
 pub struct Sha256State(Pin<Box<Sha256InnerState>>);
 
-pub struct Sha256InnerState{
+pub struct Sha256InnerState {
     inner: symcrypt_sys::SYMCRYPT_SHA256_STATE,
     _pinned: PhantomPinned
 }
@@ -395,6 +395,11 @@ impl Sha256State {
         }
         instance
     }
+
+    // test this: make Sha256InnerState.inner() Box<> 
+    // then try to cast to PSYMCRYPT_STATE 
+    // inner.0 as *mut symcrypt_sys::SYMCRYPT_STATE
+
 
     // Safe method to access the inner state mutably
     pub(crate) fn get_inner_mut(&mut self) -> Pin<&mut symcrypt_sys::SYMCRYPT_SHA256_STATE> {

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -192,7 +192,7 @@ pub struct Md5State(Pin<Box<Md5InnerState>>);
 struct Md5InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_MD5_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
@@ -207,7 +207,10 @@ struct Md5InnerState {
 #[cfg(feature = "md5")]
 impl Md5State {
     pub fn new() -> Self {
-        let mut instance = Md5State(Box::pin(Md5InnerState { inner: symcrypt_sys::SYMCRYPT_MD5_STATE::default(), _pinned: PhantomPinned }));
+        let mut instance = Md5State(Box::pin(Md5InnerState {
+            inner: symcrypt_sys::SYMCRYPT_MD5_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptMd5Init(instance.get_inner_mut());
@@ -218,11 +221,9 @@ impl Md5State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_MD5_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
 
     // Safe method to access the inner state immutably
@@ -263,7 +264,10 @@ impl HashState for Md5State {
 #[cfg(feature = "md5")]
 impl Clone for Md5State {
     fn clone(&self) -> Self {
-        let mut new_state = Md5State(Box::pin(Md5InnerState { inner: symcrypt_sys::SYMCRYPT_MD5_STATE::default(), _pinned: PhantomPinned }));
+        let mut new_state = Md5State(Box::pin(Md5InnerState {
+            inner: symcrypt_sys::SYMCRYPT_MD5_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptMd5StateCopy(self.get_inner(), new_state.get_inner_mut());
@@ -312,7 +316,7 @@ pub struct Sha1State(Pin<Box<Sha1InnerState>>);
 struct Sha1InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA1_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
@@ -328,7 +332,10 @@ struct Sha1InnerState {
 #[cfg(feature = "sha1")]
 impl Sha1State {
     pub fn new() -> Self {
-        let mut instance = Sha1State(Box::pin(Sha1InnerState { inner: symcrypt_sys::SYMCRYPT_SHA1_STATE::default(), _pinned: PhantomPinned }));
+        let mut instance = Sha1State(Box::pin(Sha1InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA1_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha1Init(instance.get_inner_mut());
@@ -339,11 +346,9 @@ impl Sha1State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA1_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
 
     // Safe method to access the inner state immutably
@@ -384,7 +389,10 @@ impl HashState for Sha1State {
 #[cfg(feature = "sha1")]
 impl Clone for Sha1State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha1State(Box::pin(Sha1InnerState { inner: symcrypt_sys::SYMCRYPT_SHA1_STATE::default(), _pinned: PhantomPinned }));
+        let mut new_state = Sha1State(Box::pin(Sha1InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA1_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha1StateCopy(self.get_inner(), new_state.get_inner_mut());
@@ -431,11 +439,11 @@ pub struct Sha256State(Pin<Box<Sha256InnerState>>);
 struct Sha256InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA256_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
-    _pinned: PhantomPinned
+    _pinned: PhantomPinned,
 }
 
 // Sha256State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
@@ -446,7 +454,10 @@ struct Sha256InnerState {
 
 impl Sha256State {
     pub fn new() -> Self {
-        let mut instance = Sha256State(Box::pin(Sha256InnerState{inner: symcrypt_sys::SYMCRYPT_SHA256_STATE::default(), _pinned: PhantomPinned}));
+        let mut instance = Sha256State(Box::pin(Sha256InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA256_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha256Init(instance.get_inner_mut());
@@ -457,13 +468,11 @@ impl Sha256State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA256_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
-    
+
     // Safe method to access the inner state immutably
     pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA256_STATE {
         &self.0.as_ref().get_ref().inner as *const _
@@ -500,7 +509,10 @@ impl HashState for Sha256State {
 
 impl Clone for Sha256State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha256State(Box::pin(Sha256InnerState{inner: symcrypt_sys::SYMCRYPT_SHA256_STATE::default(), _pinned: PhantomPinned}));
+        let mut new_state = Sha256State(Box::pin(Sha256InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA256_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha256StateCopy(self.get_inner(), new_state.get_inner_mut());
@@ -545,7 +557,7 @@ pub struct Sha384State(Pin<Box<Sha384InnerState>>);
 struct Sha384InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA384_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
@@ -560,7 +572,10 @@ struct Sha384InnerState {
 
 impl Sha384State {
     pub fn new() -> Self {
-        let mut instance = Sha384State(Box::pin(Sha384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA384_STATE::default(), _pinned: PhantomPinned }));
+        let mut instance = Sha384State(Box::pin(Sha384InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA384_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha384Init(instance.get_inner_mut());
@@ -571,11 +586,9 @@ impl Sha384State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA384_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
 
     // Safe method to access the inner state immutably
@@ -614,7 +627,10 @@ impl HashState for Sha384State {
 
 impl Clone for Sha384State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha384State(Box::pin(Sha384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA384_STATE::default(), _pinned: PhantomPinned }));
+        let mut new_state = Sha384State(Box::pin(Sha384InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA384_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha384StateCopy(self.get_inner(), new_state.get_inner_mut());
@@ -628,8 +644,8 @@ impl Drop for Sha384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                self.get_inner_mut() as *mut c_void, 
-                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T, 
+                self.get_inner_mut() as *mut c_void,
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
@@ -659,7 +675,7 @@ pub struct Sha512State(Pin<Box<Sha512InnerState>>);
 struct Sha512InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA512_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
@@ -674,7 +690,10 @@ struct Sha512InnerState {
 
 impl Sha512State {
     pub fn new() -> Self {
-        let mut instance = Sha512State(Box::pin(Sha512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA512_STATE::default(), _pinned: PhantomPinned }));
+        let mut instance = Sha512State(Box::pin(Sha512InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA512_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha512Init(instance.get_inner_mut());
@@ -685,11 +704,9 @@ impl Sha512State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA512_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
 
     // Safe method to access the inner state immutably
@@ -728,7 +745,10 @@ impl HashState for Sha512State {
 
 impl Clone for Sha512State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha512State(Box::pin(Sha512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA512_STATE::default(), _pinned: PhantomPinned }));
+        let mut new_state = Sha512State(Box::pin(Sha512InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA512_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha512StateCopy(self.get_inner(), new_state.get_inner_mut());
@@ -742,8 +762,8 @@ impl Drop for Sha512State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                self.get_inner_mut() as *mut c_void, 
-                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T, 
+                self.get_inner_mut() as *mut c_void,
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
@@ -773,7 +793,7 @@ pub struct Sha3_256State(Pin<Box<Sha3_256InnerState>>);
 struct Sha3_256InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
@@ -788,7 +808,10 @@ struct Sha3_256InnerState {
 
 impl Sha3_256State {
     pub fn new() -> Self {
-        let mut instance = Sha3_256State(Box::pin(Sha3_256InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default(), _pinned: PhantomPinned }));
+        let mut instance = Sha3_256State(Box::pin(Sha3_256InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_256Init(instance.get_inner_mut());
@@ -799,11 +822,9 @@ impl Sha3_256State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA3_256_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
 
     // Safe method to access the inner state immutably
@@ -842,7 +863,10 @@ impl HashState for Sha3_256State {
 
 impl Clone for Sha3_256State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha3_256State(Box::pin(Sha3_256InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default(), _pinned: PhantomPinned }));
+        let mut new_state = Sha3_256State(Box::pin(Sha3_256InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_256StateCopy(self.get_inner(), new_state.get_inner_mut());
@@ -887,7 +911,7 @@ pub struct Sha3_384State(Pin<Box<Sha3_384InnerState>>);
 struct Sha3_384InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
@@ -902,7 +926,10 @@ struct Sha3_384InnerState {
 
 impl Sha3_384State {
     pub fn new() -> Self {
-        let mut instance = Sha3_384State(Box::pin(Sha3_384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default(), _pinned: PhantomPinned }));
+        let mut instance = Sha3_384State(Box::pin(Sha3_384InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_384Init(instance.get_inner_mut());
@@ -913,11 +940,9 @@ impl Sha3_384State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA3_384_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
 
     // Safe method to access the inner state immutably
@@ -956,7 +981,10 @@ impl HashState for Sha3_384State {
 
 impl Clone for Sha3_384State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha3_384State(Box::pin(Sha3_384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default(), _pinned: PhantomPinned }));
+        let mut new_state = Sha3_384State(Box::pin(Sha3_384InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_384StateCopy(self.get_inner(), new_state.get_inner_mut());
@@ -970,7 +998,7 @@ impl Drop for Sha3_384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                self.get_inner_mut() as *mut c_void, 
+                self.get_inner_mut() as *mut c_void,
                 mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
@@ -1001,7 +1029,7 @@ pub struct Sha3_512State(Pin<Box<Sha3_512InnerState>>);
 struct Sha3_512InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE,
-    
+
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
@@ -1016,7 +1044,10 @@ struct Sha3_512InnerState {
 
 impl Sha3_512State {
     pub fn new() -> Self {
-        let mut instance = Sha3_512State(Box::pin(Sha3_512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default(), _pinned: PhantomPinned }));
+        let mut instance = Sha3_512State(Box::pin(Sha3_512InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_512Init(instance.get_inner_mut());
@@ -1027,11 +1058,9 @@ impl Sha3_512State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA3_512_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
-            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
-        }
+        unsafe { &mut self.0.as_mut().get_unchecked_mut().inner as *mut _ }
     }
 
     // Safe method to access the inner state immutably
@@ -1070,7 +1099,10 @@ impl HashState for Sha3_512State {
 
 impl Clone for Sha3_512State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha3_512State(Box::pin(Sha3_512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default(), _pinned: PhantomPinned }));
+        let mut new_state = Sha3_512State(Box::pin(Sha3_512InnerState {
+            inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default(),
+            _pinned: PhantomPinned,
+        }));
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_512StateCopy(self.get_inner(), new_state.get_inner_mut());

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -399,8 +399,14 @@ impl Sha256State {
         instance
     }
 
-    // Safe method to access the inner state mutably
-    pub(crate) fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA256_STATE {
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    ///
+    /// ## Safety:
+    /// 
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA256_STATE {
         unsafe { 
             // SAFETY: getting a mutable raw pointer to the inner state
             &mut self.0.as_mut().get_unchecked_mut().inner as *mut _

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -74,7 +74,6 @@ use core::ffi::c_void;
 use std::marker::PhantomPinned;
 use std::mem;
 use std::pin::Pin;
-use std::ptr;
 use symcrypt_sys;
 
 /// 16
@@ -187,7 +186,19 @@ pub trait HashState: Clone {
 
 /// [`Md5State`] is a struct that represents a stateful md5 hash and implements the [`HashState`] trait.
 #[cfg(feature = "md5")]
-pub struct Md5State(Pin<Box<symcrypt_sys::SYMCRYPT_MD5_STATE>>);
+pub struct Md5State(Pin<Box<Md5InnerState>>);
+
+#[cfg(feature = "md5")]
+struct Md5InnerState {
+    // inner represents the actual state of the hash from SymCrypt
+    inner: symcrypt_sys::SYMCRYPT_MD5_STATE,
+    
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
 // Md5State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Md5State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -196,12 +207,27 @@ pub struct Md5State(Pin<Box<symcrypt_sys::SYMCRYPT_MD5_STATE>>);
 #[cfg(feature = "md5")]
 impl Md5State {
     pub fn new() -> Self {
-        let mut instance = Md5State(Box::pin(symcrypt_sys::SYMCRYPT_MD5_STATE::default()));
+        let mut instance = Md5State(Box::pin(Md5InnerState { inner: symcrypt_sys::SYMCRYPT_MD5_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptMd5Init(&mut *instance.0);
+            symcrypt_sys::SymCryptMd5Init(instance.get_inner_mut());
         }
         instance
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_MD5_STATE {
+        unsafe { 
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    // Safe method to access the inner state immutably
+    pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_MD5_STATE {
+        &self.0.as_ref().get_ref().inner as *const _
     }
 }
 
@@ -213,7 +239,7 @@ impl HashState for Md5State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptMd5Append(
-                &mut *self.0,
+                self.get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             );
@@ -224,7 +250,7 @@ impl HashState for Md5State {
         let mut result = [0u8; MD5_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptMd5Result(&mut *self.0, result.as_mut_ptr());
+            symcrypt_sys::SymCryptMd5Result(self.get_inner_mut(), result.as_mut_ptr());
         }
         result
     }
@@ -237,10 +263,10 @@ impl HashState for Md5State {
 #[cfg(feature = "md5")]
 impl Clone for Md5State {
     fn clone(&self) -> Self {
-        let mut new_state = Md5State(Box::pin(symcrypt_sys::SYMCRYPT_MD5_STATE::default()));
+        let mut new_state = Md5State(Box::pin(Md5InnerState { inner: symcrypt_sys::SYMCRYPT_MD5_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptMd5StateCopy(&*self.0, &mut *new_state.0);
+            symcrypt_sys::SymCryptMd5StateCopy(self.get_inner(), new_state.get_inner_mut());
         }
         new_state
     }
@@ -252,9 +278,9 @@ impl Drop for Md5State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void,
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
+            );
         }
     }
 }
@@ -280,7 +306,19 @@ pub fn md5(data: &[u8]) -> [u8; MD5_RESULT_SIZE] {
 
 /// [`Sha1State`] is a struct that represents a stateful sha1 hash and implements the [`HashState`] trait.
 #[cfg(feature = "sha1")]
-pub struct Sha1State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA1_STATE>>);
+pub struct Sha1State(Pin<Box<Sha1InnerState>>);
+
+#[cfg(feature = "sha1")]
+struct Sha1InnerState {
+    // inner represents the actual state of the hash from SymCrypt
+    inner: symcrypt_sys::SYMCRYPT_SHA1_STATE,
+    
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
 // Sha1State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Sha1State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -290,12 +328,27 @@ pub struct Sha1State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA1_STATE>>);
 #[cfg(feature = "sha1")]
 impl Sha1State {
     pub fn new() -> Self {
-        let mut instance = Sha1State(Box::pin(symcrypt_sys::SYMCRYPT_SHA1_STATE::default()));
+        let mut instance = Sha1State(Box::pin(Sha1InnerState { inner: symcrypt_sys::SYMCRYPT_SHA1_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha1Init(&mut *instance.0);
+            symcrypt_sys::SymCryptSha1Init(instance.get_inner_mut());
         }
         instance
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA1_STATE {
+        unsafe { 
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    // Safe method to access the inner state immutably
+    pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA1_STATE {
+        &self.0.as_ref().get_ref().inner as *const _
     }
 }
 
@@ -307,7 +360,7 @@ impl HashState for Sha1State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha1Append(
-                &mut *self.0,
+                self.get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             );
@@ -318,7 +371,7 @@ impl HashState for Sha1State {
         let mut result = [0u8; SHA1_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha1Result(&mut *self.0, result.as_mut_ptr());
+            symcrypt_sys::SymCryptSha1Result(self.get_inner_mut(), result.as_mut_ptr());
         }
         result
     }
@@ -331,10 +384,10 @@ impl HashState for Sha1State {
 #[cfg(feature = "sha1")]
 impl Clone for Sha1State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha1State(Box::pin(symcrypt_sys::SYMCRYPT_SHA1_STATE::default()));
+        let mut new_state = Sha1State(Box::pin(Sha1InnerState { inner: symcrypt_sys::SYMCRYPT_SHA1_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha1StateCopy(&*self.0, &mut *new_state.0);
+            symcrypt_sys::SymCryptSha1StateCopy(self.get_inner(), new_state.get_inner_mut());
         }
         new_state
     }
@@ -346,9 +399,9 @@ impl Drop for Sha1State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void,
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
+            );
         }
     }
 }
@@ -374,15 +427,17 @@ pub fn sha1(data: &[u8]) -> [u8; SHA1_RESULT_SIZE] {
 
 /// [`Sha256State`] is a struct that represents a stateful sha256 hash and implements the [`HashState`] trait.
 pub struct Sha256State(Pin<Box<Sha256InnerState>>);
-pub struct Sha256InnerState {
+
+struct Sha256InnerState {
     // inner represents the actual state of the hash from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_SHA256_STATE,
     
     // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
     //  This prevents the struct from implementing the Unpin trait, enforcing that any
     //  references to this structure remain valid throughout its lifetime.
-        _pinned: PhantomPinned
+    _pinned: PhantomPinned
 }
+
 // Sha256State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Sha256State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -402,13 +457,9 @@ impl Sha256State {
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
-    ///
-    /// ## Safety:
-    /// 
-    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA256_STATE {
         unsafe { 
-            // SAFETY: getting a mutable raw pointer to the inner state
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
             &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
         }
     }
@@ -463,9 +514,9 @@ impl Drop for Sha256State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                self.get_inner() as *mut c_void,
-                mem::size_of_val(&mut self.get_inner()) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void,
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
+            );
         }
     }
 }
@@ -489,7 +540,18 @@ pub fn sha256(data: &[u8]) -> [u8; SHA256_RESULT_SIZE] {
 }
 
 /// [`Sha384State`] is a struct that represents a stateful sha384 hash and implements the [`HashState`] trait.
-pub struct Sha384State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA384_STATE>>);
+pub struct Sha384State(Pin<Box<Sha384InnerState>>);
+
+struct Sha384InnerState {
+    // inner represents the actual state of the hash from SymCrypt
+    inner: symcrypt_sys::SYMCRYPT_SHA384_STATE,
+    
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
 // Sha384State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Sha384State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -498,12 +560,27 @@ pub struct Sha384State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA384_STATE>>);
 
 impl Sha384State {
     pub fn new() -> Self {
-        let mut instance = Sha384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA384_STATE::default()));
+        let mut instance = Sha384State(Box::pin(Sha384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA384_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha384Init(&mut *instance.0);
+            symcrypt_sys::SymCryptSha384Init(instance.get_inner_mut());
         }
         instance
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA384_STATE {
+        unsafe { 
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    // Safe method to access the inner state immutably
+    pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA384_STATE {
+        &self.0.as_ref().get_ref().inner as *const _
     }
 }
 
@@ -514,7 +591,7 @@ impl HashState for Sha384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha384Append(
-                &mut *self.0,
+                self.get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             );
@@ -525,7 +602,7 @@ impl HashState for Sha384State {
         let mut result = [0u8; SHA384_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha384Result(&mut *self.0, result.as_mut_ptr());
+            symcrypt_sys::SymCryptSha384Result(self.get_inner_mut(), result.as_mut_ptr());
         }
         result
     }
@@ -537,10 +614,10 @@ impl HashState for Sha384State {
 
 impl Clone for Sha384State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA384_STATE::default()));
+        let mut new_state = Sha384State(Box::pin(Sha384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA384_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha384StateCopy(&*self.0, &mut *new_state.0);
+            symcrypt_sys::SymCryptSha384StateCopy(self.get_inner(), new_state.get_inner_mut());
         }
         new_state
     }
@@ -551,9 +628,9 @@ impl Drop for Sha384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void, 
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T, 
+            );
         }
     }
 }
@@ -577,7 +654,18 @@ pub fn sha384(data: &[u8]) -> [u8; SHA384_RESULT_SIZE] {
 }
 
 /// [`Sha512State`] is a struct that represents a stateful sha512 hash and implements the [`HashState`] trait.
-pub struct Sha512State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA512_STATE>>);
+pub struct Sha512State(Pin<Box<Sha512InnerState>>);
+
+struct Sha512InnerState {
+    // inner represents the actual state of the hash from SymCrypt
+    inner: symcrypt_sys::SYMCRYPT_SHA512_STATE,
+    
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
 // Sha512State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Sha512State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -586,12 +674,27 @@ pub struct Sha512State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA512_STATE>>);
 
 impl Sha512State {
     pub fn new() -> Self {
-        let mut instance = Sha512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA512_STATE::default()));
+        let mut instance = Sha512State(Box::pin(Sha512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA512_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha512Init(&mut *instance.0);
+            symcrypt_sys::SymCryptSha512Init(instance.get_inner_mut());
         }
         instance
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA512_STATE {
+        unsafe { 
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    // Safe method to access the inner state immutably
+    pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA512_STATE {
+        &self.0.as_ref().get_ref().inner as *const _
     }
 }
 
@@ -602,7 +705,7 @@ impl HashState for Sha512State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha512Append(
-                &mut *self.0,
+                self.get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             );
@@ -613,7 +716,7 @@ impl HashState for Sha512State {
         let mut result = [0u8; SHA512_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha512Result(&mut *self.0, result.as_mut_ptr());
+            symcrypt_sys::SymCryptSha512Result(self.get_inner_mut(), result.as_mut_ptr());
         }
         result
     }
@@ -625,10 +728,10 @@ impl HashState for Sha512State {
 
 impl Clone for Sha512State {
     fn clone(&self) -> Self {
-        let mut new_state = Sha512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA512_STATE::default()));
+        let mut new_state = Sha512State(Box::pin(Sha512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA512_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha512StateCopy(&*self.0, &mut *new_state.0);
+            symcrypt_sys::SymCryptSha512StateCopy(self.get_inner(), new_state.get_inner_mut());
         }
         new_state
     }
@@ -639,9 +742,9 @@ impl Drop for Sha512State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void, 
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T, 
+            );
         }
     }
 }
@@ -665,7 +768,18 @@ pub fn sha512(data: &[u8]) -> [u8; SHA512_RESULT_SIZE] {
 }
 
 /// [`Sha3_256State`] is a struct that represents a stateful sha3_256 hash and implements the [`HashState`] trait.
-pub struct Sha3_256State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_256_STATE>>);
+pub struct Sha3_256State(Pin<Box<Sha3_256InnerState>>);
+
+struct Sha3_256InnerState {
+    // inner represents the actual state of the hash from SymCrypt
+    inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE,
+    
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
 // Sha3_256State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Sha3_256State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -674,13 +788,27 @@ pub struct Sha3_256State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_256_STATE>>);
 
 impl Sha3_256State {
     pub fn new() -> Self {
-        let mut instance =
-            Sha3_256State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default()));
+        let mut instance = Sha3_256State(Box::pin(Sha3_256InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_256Init(&mut *instance.0);
+            symcrypt_sys::SymCryptSha3_256Init(instance.get_inner_mut());
         }
         instance
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA3_256_STATE {
+        unsafe { 
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    // Safe method to access the inner state immutably
+    pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA3_256_STATE {
+        &self.0.as_ref().get_ref().inner as *const _
     }
 }
 
@@ -691,7 +819,7 @@ impl HashState for Sha3_256State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_256Append(
-                &mut *self.0,
+                self.get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             );
@@ -702,7 +830,7 @@ impl HashState for Sha3_256State {
         let mut result = [0u8; SHA3_256_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_256Result(&mut *self.0, result.as_mut_ptr());
+            symcrypt_sys::SymCryptSha3_256Result(self.get_inner_mut(), result.as_mut_ptr());
         }
         result
     }
@@ -714,11 +842,10 @@ impl HashState for Sha3_256State {
 
 impl Clone for Sha3_256State {
     fn clone(&self) -> Self {
-        let mut new_state =
-            Sha3_256State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default()));
+        let mut new_state = Sha3_256State(Box::pin(Sha3_256InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_256_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_256StateCopy(&*self.0, &mut *new_state.0);
+            symcrypt_sys::SymCryptSha3_256StateCopy(self.get_inner(), new_state.get_inner_mut());
         }
         new_state
     }
@@ -729,9 +856,9 @@ impl Drop for Sha3_256State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void,
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
+            );
         }
     }
 }
@@ -755,7 +882,18 @@ pub fn sha3_256(data: &[u8]) -> [u8; SHA3_256_RESULT_SIZE] {
 }
 
 /// [`Sha3_384State`] is a struct that represents a stateful sha3_384 hash and implements the [`HashState`] trait.
-pub struct Sha3_384State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_384_STATE>>);
+pub struct Sha3_384State(Pin<Box<Sha3_384InnerState>>);
+
+struct Sha3_384InnerState {
+    // inner represents the actual state of the hash from SymCrypt
+    inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE,
+    
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
 // Sha3_384State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Sha3_384State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -764,13 +902,27 @@ pub struct Sha3_384State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_384_STATE>>);
 
 impl Sha3_384State {
     pub fn new() -> Self {
-        let mut instance =
-            Sha3_384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default()));
+        let mut instance = Sha3_384State(Box::pin(Sha3_384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_384Init(&mut *instance.0);
+            symcrypt_sys::SymCryptSha3_384Init(instance.get_inner_mut());
         }
         instance
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA3_384_STATE {
+        unsafe { 
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    // Safe method to access the inner state immutably
+    pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA3_384_STATE {
+        &self.0.as_ref().get_ref().inner as *const _
     }
 }
 
@@ -781,7 +933,7 @@ impl HashState for Sha3_384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_384Append(
-                &mut *self.0,
+                self.get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             );
@@ -792,7 +944,7 @@ impl HashState for Sha3_384State {
         let mut result = [0u8; SHA3_384_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_384Result(&mut *self.0, result.as_mut_ptr());
+            symcrypt_sys::SymCryptSha3_384Result(self.get_inner_mut(), result.as_mut_ptr());
         }
         result
     }
@@ -804,11 +956,10 @@ impl HashState for Sha3_384State {
 
 impl Clone for Sha3_384State {
     fn clone(&self) -> Self {
-        let mut new_state =
-            Sha3_384State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default()));
+        let mut new_state = Sha3_384State(Box::pin(Sha3_384InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_384_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_384StateCopy(&*self.0, &mut *new_state.0);
+            symcrypt_sys::SymCryptSha3_384StateCopy(self.get_inner(), new_state.get_inner_mut());
         }
         new_state
     }
@@ -819,9 +970,9 @@ impl Drop for Sha3_384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void, 
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
+            );
         }
     }
 }
@@ -845,7 +996,18 @@ pub fn sha3_384(data: &[u8]) -> [u8; SHA3_384_RESULT_SIZE] {
 }
 
 /// [`Sha3_512State`] is a struct that represents a stateful sha3_512 hash and implements the [`HashState`] trait.
-pub struct Sha3_512State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_512_STATE>>);
+pub struct Sha3_512State(Pin<Box<Sha3_512InnerState>>);
+
+struct Sha3_512InnerState {
+    // inner represents the actual state of the hash from SymCrypt
+    inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE,
+    
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
 // Sha3_512State needs to have a heap allocated inner state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
 // around when returning from Sha3_512State::new(). Box<> heap allocates the memory and ensures that it does not move
 //
@@ -854,13 +1016,27 @@ pub struct Sha3_512State(Pin<Box<symcrypt_sys::SYMCRYPT_SHA3_512_STATE>>);
 
 impl Sha3_512State {
     pub fn new() -> Self {
-        let mut instance =
-            Sha3_512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default()));
+        let mut instance = Sha3_512State(Box::pin(Sha3_512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_512Init(&mut *instance.0);
+            symcrypt_sys::SymCryptSha3_512Init(instance.get_inner_mut());
         }
         instance
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    fn get_inner_mut(&mut self) -> *mut symcrypt_sys::SYMCRYPT_SHA3_512_STATE {
+        unsafe { 
+            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+            &mut self.0.as_mut().get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    // Safe method to access the inner state immutably
+    pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA3_512_STATE {
+        &self.0.as_ref().get_ref().inner as *const _
     }
 }
 
@@ -871,7 +1047,7 @@ impl HashState for Sha3_512State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptSha3_512Append(
-                &mut *self.0,
+                self.get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             );
@@ -882,7 +1058,7 @@ impl HashState for Sha3_512State {
         let mut result = [0u8; SHA3_512_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_512Result(&mut *self.0, result.as_mut_ptr());
+            symcrypt_sys::SymCryptSha3_512Result(self.get_inner_mut(), result.as_mut_ptr());
         }
         result
     }
@@ -894,11 +1070,10 @@ impl HashState for Sha3_512State {
 
 impl Clone for Sha3_512State {
     fn clone(&self) -> Self {
-        let mut new_state =
-            Sha3_512State(Box::pin(symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default()));
+        let mut new_state = Sha3_512State(Box::pin(Sha3_512InnerState { inner: symcrypt_sys::SYMCRYPT_SHA3_512_STATE::default(), _pinned: PhantomPinned }));
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptSha3_512StateCopy(&*self.0, &mut *new_state.0);
+            symcrypt_sys::SymCryptSha3_512StateCopy(self.get_inner(), new_state.get_inner_mut());
         }
         new_state
     }
@@ -909,9 +1084,9 @@ impl Drop for Sha3_512State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
-            )
+                self.get_inner_mut() as *mut c_void,
+                mem::size_of_val(&*self.get_inner()) as symcrypt_sys::SIZE_T,
+            );
         }
     }
 }

--- a/rust-symcrypt/src/hmac.rs
+++ b/rust-symcrypt/src/hmac.rs
@@ -71,11 +71,11 @@
 
 use crate::errors::SymCryptError;
 use core::ffi::c_void;
+use std::marker::PhantomPinned;
 use std::mem;
 use std::pin::Pin;
 use std::ptr;
 use std::sync::Arc;
-use std::marker::PhantomPinned;
 use symcrypt_sys;
 
 /// 16
@@ -458,37 +458,38 @@ pub fn hmac_sha1(key: &[u8], data: &[u8]) -> Result<[u8; SHA1_HMAC_RESULT_SIZE],
 }
 
 /// `HmacSha256ExpandedKey` is a struct that represents the expanded key for the [`HmacSha256State`].
+/// The key wrapping so that it can be independently dropped after it's ref count has gone to 0
 struct HmacSha256ExpandedKey {
+    // inner represents the actual hmac state from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_HMAC_SHA256_EXPANDED_KEY,
-    _pinned: PhantomPinned
+
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
 }
-// Wrapping the expanded key so that it can be independently dropped after it's ref count has gone to 0
 
 impl HmacSha256ExpandedKey {
-    // SAFETY: FFI calls
     fn new(key: &[u8]) -> Result<Pin<Box<Self>>, SymCryptError> {
-        // Use Box::pin to ensure the data is pinned in place and then wrap in Arc
         let mut expanded_key = Box::pin(HmacSha256ExpandedKey {
             inner: symcrypt_sys::SYMCRYPT_HMAC_SHA256_EXPANDED_KEY::default(),
             _pinned: PhantomPinned,
         });
 
         unsafe {
+            // SAFETY: FFI calls
             match symcrypt_sys::SymCryptHmacSha256ExpandKey(
                 &mut expanded_key.as_mut().get_unchecked_mut().inner,
                 key.as_ptr(),
                 key.len() as symcrypt_sys::SIZE_T,
             ) {
-                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => {
-                    // Wrap the pinned Box in an Arc
-                    Ok(expanded_key)
-                },
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(expanded_key),
                 err => Err(err.into()),
             }
         }
     }
 
-    // Safe method to access the inner state immutably
+    /// Safe method to access the inner state immutably
     fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_HMAC_SHA256_EXPANDED_KEY {
         &self.inner as *const _
     }
@@ -507,7 +508,7 @@ impl Drop for HmacSha256ExpandedKey {
     }
 }
 
-/// `HmacSha256State` is a struct that represents a stateful Hmac using SHA256 and implements the [`HmacState`] trait.
+/// `HmacSha256State` is a struct that represents a stateful HMAC using SHA256 and implements the [`HmacState`] trait.
 pub struct HmacSha256State {
     // SymCrypt expects the address for its structs to stay static through the struct's lifetime to guarantee that structs are not memcpy'd as
     // doing so would lead to use-after-free and inconsistent states.
@@ -522,7 +523,12 @@ pub struct HmacSha256State {
     key: Arc<Pin<Box<HmacSha256ExpandedKey>>>,
 }
 struct HmacSha256Inner {
+    // inner represents the actual HMAC state from SymCrypt
     inner: symcrypt_sys::SYMCRYPT_HMAC_SHA256_STATE,
+
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    //  This prevents the struct from implementing the Unpin trait, enforcing that any
+    //  references to this structure remain valid throughout its lifetime.
     _pinned: PhantomPinned,
 }
 
@@ -530,20 +536,22 @@ impl HmacSha256Inner {
     fn new() -> Pin<Box<Self>> {
         Box::pin(HmacSha256Inner {
             inner: symcrypt_sys::SYMCRYPT_HMAC_SHA256_STATE::default(),
-            _pinned: PhantomPinned
+            _pinned: PhantomPinned,
         })
     }
 
     /// Get a mutable pointer to the inner SymCrypt state
     ///
     /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
     fn get_inner_mut(self: Pin<&mut Self>) -> *mut symcrypt_sys::SYMCRYPT_HMAC_SHA256_STATE {
-        unsafe { 
-            // This function returns pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+        unsafe {
+            // SAFETY: Accessing the inner state of the pinned data
             &mut self.get_unchecked_mut().inner as *mut _
         }
     }
 
+    /// Safe method to access the inner state immutably
     fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_HMAC_SHA256_STATE {
         &self.inner as *const _
     }
@@ -558,11 +566,11 @@ unsafe impl Sync for HmacSha256Inner {
 }
 
 impl HmacSha256State {
-    /// `new()` takes in a reference to a key and can return a `SymCryptError` that is propagated back to the caller.
+    /// `new()` takes in a `&[u8]` reference to a key and can return a [`SymCryptError`] that is propagated back to the caller.
     pub fn new(key: &[u8]) -> Result<Self, SymCryptError> {
         let expanded_key = HmacSha256ExpandedKey::new(key)?;
         let mut inner_state = HmacSha256Inner::new();
-        
+
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptHmacSha256Init(
@@ -573,7 +581,7 @@ impl HmacSha256State {
 
         Ok(HmacSha256State {
             state: inner_state,
-            key: Arc::new(expanded_key)
+            key: Arc::new(expanded_key),
         })
     }
 }
@@ -596,7 +604,10 @@ impl HmacState for HmacSha256State {
         let mut result = [0u8; SHA256_HMAC_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptHmacSha256Result(self.state.as_mut().get_inner_mut(), result.as_mut_ptr());
+            symcrypt_sys::SymCryptHmacSha256Result(
+                self.state.as_mut().get_inner_mut(),
+                result.as_mut_ptr(),
+            );
         }
         result
     }
@@ -635,7 +646,7 @@ impl Drop for HmacSha256State {
     }
 }
 
-/// Stateless Hmac function for HmacSha256.
+/// Stateless HMAC function for HmacSha256.
 ///
 /// `key` is a reference to a key.
 ///
@@ -670,43 +681,104 @@ pub fn hmac_sha256(
 }
 
 /// `HmacSha384ExpandedKey` is a struct that represents the expanded key for the [`HmacSha384State`].
-struct HmacSha384ExpandedKey(symcrypt_sys::SYMCRYPT_HMAC_SHA384_EXPANDED_KEY);
-// Wrapping the expanded key so that it can be independently dropped after it's ref count has gone to 0
+/// The key wrapping so that it can be independently dropped after its ref count has gone to 0.
+struct HmacSha384ExpandedKey {
+    // inner represents the actual HMAC state from SymCrypt.
+    inner: symcrypt_sys::SYMCRYPT_HMAC_SHA384_EXPANDED_KEY,
 
-// Since HmacSha384ExpandedKey can be referenced multiple times, HmacSha384ExpandedKey must be ref counted and there needs to be a separate drop()
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    // This prevents the struct from implementing the Unpin trait, enforcing that any
+    // references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
+impl HmacSha384ExpandedKey {
+    fn new(key: &[u8]) -> Result<Pin<Box<Self>>, SymCryptError> {
+        let mut expanded_key = Box::pin(HmacSha384ExpandedKey {
+            inner: symcrypt_sys::SYMCRYPT_HMAC_SHA384_EXPANDED_KEY::default(),
+            _pinned: PhantomPinned,
+        });
+
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptHmacSha384ExpandKey(
+                &mut expanded_key.as_mut().get_unchecked_mut().inner,
+                key.as_ptr(),
+                key.len() as symcrypt_sys::SIZE_T,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(expanded_key),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// Safe method to access the inner state immutably.
+    fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_HMAC_SHA384_EXPANDED_KEY {
+        &self.inner as *const _
+    }
+}
+
+// Since HmacSha384ExpandedKey can be referenced multiple times, HmacSha384ExpandedKey must be ref counted and there needs to be a separate drop().
 impl Drop for HmacSha384ExpandedKey {
     fn drop(&mut self) {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
+                ptr::addr_of_mut!(self.inner) as *mut c_void,
+                mem::size_of_val(&mut self.inner) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
-/// `HmacSha384State` is a struct that represents a stateful Hmac using SHA384 and implements the [`HmacState`] trait.
+/// `HmacSha384State` is a struct that represents a stateful HMAC using SHA384 and implements the [`HmacState`] trait.
 pub struct HmacSha384State {
-    // Using an `HmacSha256Inner` state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
-    // around when returning from `HmacSha256State::new()`. Box<> heap allocates the memory and ensures that it does not move
-    // within its lifetime.
-    //
-    // `expanded_key` is Arc<>'d to be properly ref counted when calling `HmacShaXXXState::clone()`.
-    //
-    // SymCrypt expects the address for its structs to stay static through the structs lifetime to guarantee that structs are not memcpy'd as
+    // SymCrypt expects the address for its structs to stay static through the struct's lifetime to guarantee that structs are not memcpy'd as
     // doing so would lead to use-after-free and inconsistent states.
-    inner: Pin<Box<HmacSha384Inner>>,
+
+    // Using an `HmacSha384Inner` state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
+    // around when returning from `HmacSha384State::new()`. Box<> heap allocates the memory and ensures that it does not move
+    // within its lifetime.
+    state: Pin<Box<HmacSha384Inner>>,
+
+    // Must Arc<> the expanded_key field since it must be ref counted; clones of HmacSha384State will reference the same expanded key.
+    // Arc<T> pointer can move, but its reference T is Pin<Box<>>'d to ensure that the address does not move during its lifetime.
+    key: Arc<Pin<Box<HmacSha384ExpandedKey>>>,
 }
 
 struct HmacSha384Inner {
-    state: symcrypt_sys::SYMCRYPT_HMAC_SHA384_STATE,
+    // inner represents the actual HMAC state from SymCrypt.
+    inner: symcrypt_sys::SYMCRYPT_HMAC_SHA384_STATE,
 
-    // Must Arc<> the expanded_key field since it must be ref counted, clones of HmacSha384tate will reference the same expanded key. Pin<> on the key
-    // is to ensure that address is not moved throughout the expanded key's lifetime.
-    //
-    // This semantic is not needed for the state field since it is initialized in line with HmacSha384Inner initialization.
-    expanded_key: Pin<Arc<HmacSha384ExpandedKey>>,
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    // This prevents the struct from implementing the Unpin trait, enforcing that any
+    // references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
+impl HmacSha384Inner {
+    fn new() -> Pin<Box<Self>> {
+        Box::pin(HmacSha384Inner {
+            inner: symcrypt_sys::SYMCRYPT_HMAC_SHA384_STATE::default(),
+            _pinned: PhantomPinned,
+        })
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state.
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns a pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+    fn get_inner_mut(self: Pin<&mut Self>) -> *mut symcrypt_sys::SYMCRYPT_HMAC_SHA384_STATE {
+        unsafe {
+            // SAFETY: Accessing the inner state of the pinned data.
+            &mut self.get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    /// Safe method to access the inner state immutably.
+    fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_HMAC_SHA384_STATE {
+        &self.inner as *const _
+    }
 }
 
 unsafe impl Send for HmacSha384Inner {
@@ -718,34 +790,23 @@ unsafe impl Sync for HmacSha384Inner {
 }
 
 impl HmacSha384State {
+    /// `new()` takes in a `&[u8]` reference to a key and can return a [`SymCryptError`] that is propagated back to the caller.
     pub fn new(key: &[u8]) -> Result<Self, SymCryptError> {
-        let mut expanded_key = Arc::new(HmacSha384ExpandedKey(
-            symcrypt_sys::SYMCRYPT_HMAC_SHA384_EXPANDED_KEY::default(),
-        ));
+        let expanded_key = HmacSha384ExpandedKey::new(key)?;
+        let mut inner_state = HmacSha384Inner::new();
+
         unsafe {
             // SAFETY: FFI calls
-            match symcrypt_sys::SymCryptHmacSha384ExpandKey(
-                // Arc::get_mut() to unbind the Arc<>, &mut (T).0 to get raw pointer for SymCrypt
-                &mut (Arc::get_mut(&mut expanded_key).unwrap()).0,
-                key.as_ptr(),
-                key.len() as symcrypt_sys::SIZE_T,
-            ) {
-                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => {
-                    let mut instance = HmacSha384State {
-                        inner: Box::pin(HmacSha384Inner {
-                            state: symcrypt_sys::SYMCRYPT_HMAC_SHA384_STATE::default(),
-                            expanded_key: Pin::new(expanded_key),
-                        }),
-                    };
-                    symcrypt_sys::SymCryptHmacSha384Init(
-                        &mut instance.inner.state,
-                        &instance.inner.expanded_key.0,
-                    );
-                    Ok(instance)
-                }
-                err => Err(err.into()),
-            }
+            symcrypt_sys::SymCryptHmacSha384Init(
+                inner_state.as_mut().get_inner_mut(),
+                expanded_key.get_inner(),
+            );
         }
+
+        Ok(HmacSha384State {
+            state: inner_state,
+            key: Arc::new(expanded_key),
+        })
     }
 }
 
@@ -756,7 +817,7 @@ impl HmacState for HmacSha384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptHmacSha384Append(
-                &mut self.inner.state,
+                self.state.as_mut().get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             )
@@ -767,29 +828,30 @@ impl HmacState for HmacSha384State {
         let mut result = [0u8; SHA384_HMAC_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptHmacSha384Result(&mut self.inner.state, result.as_mut_ptr());
+            symcrypt_sys::SymCryptHmacSha384Result(
+                self.state.as_mut().get_inner_mut(),
+                result.as_mut_ptr(),
+            );
         }
         result
     }
 }
 
 /// Creates a clone of the current `HmacSha384State`. Clone will create a new state field but will reference the same
-/// expanded_key of the current HmacSha384State.
+/// `expanded_key` of the current `HmacSha384State`.
 impl Clone for HmacSha384State {
-    // Clone will increase the refcount on expanded_key field
+    // Clone will increase the refcount on the expanded_key field.
     fn clone(&self) -> Self {
         let mut new_state = HmacSha384State {
-            inner: Box::pin(HmacSha384Inner {
-                state: symcrypt_sys::SYMCRYPT_HMAC_SHA384_STATE::default(),
-                expanded_key: Pin::clone(&self.inner.expanded_key),
-            }),
+            state: HmacSha384Inner::new(),
+            key: Arc::clone(&self.key), // Clone to increase ref count.
         };
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptHmacSha384StateCopy(
-                &self.inner.state,
-                &self.inner.expanded_key.0,
-                &mut new_state.inner.state,
+                self.state.get_inner(),
+                new_state.key.get_inner(), // Use new ref counted key.
+                new_state.state.as_mut().get_inner_mut(),
             );
         }
         new_state
@@ -801,14 +863,14 @@ impl Drop for HmacSha384State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.inner.state) as *mut c_void,
-                mem::size_of_val(&mut self.inner.state) as symcrypt_sys::SIZE_T,
+                self.state.as_mut().get_inner_mut() as *mut c_void,
+                mem::size_of_val(&mut self.state.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
-/// Stateless Hmac function for HmacSha384.
+/// Stateless HMAC function for HmacSha384.
 ///
 /// `key` is a reference to a key.
 ///
@@ -822,17 +884,15 @@ pub fn hmac_sha384(
     let mut result = [0u8; SHA384_HMAC_RESULT_SIZE];
     unsafe {
         // SAFETY: FFI calls
-        let mut expanded_key =
-            HmacSha384ExpandedKey(symcrypt_sys::SYMCRYPT_HMAC_SHA384_EXPANDED_KEY::default());
+        let mut expanded_key = HmacSha384ExpandedKey::new(key)?;
         match symcrypt_sys::SymCryptHmacSha384ExpandKey(
-            // Arc not needed here since this key will not be shared
-            &mut expanded_key.0,
+            &mut expanded_key.as_mut().get_unchecked_mut().inner,
             key.as_ptr(),
             key.len() as symcrypt_sys::SIZE_T,
         ) {
             symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => {
                 symcrypt_sys::SymCryptHmacSha384(
-                    &mut expanded_key.0,
+                    &mut expanded_key.as_mut().get_unchecked_mut().inner,
                     data.as_ptr(),
                     data.len() as symcrypt_sys::SIZE_T,
                     result.as_mut_ptr(),
@@ -845,23 +905,57 @@ pub fn hmac_sha384(
 }
 
 /// `HmacSha512ExpandedKey` is a struct that represents the expanded key for the [`HmacSha512State`].
-struct HmacSha512ExpandedKey(symcrypt_sys::SYMCRYPT_HMAC_SHA512_EXPANDED_KEY);
-// Wrapping the expanded key so that it can be independently dropped after it's ref count has gone to 0
+/// The key wrapping so that it can be independently dropped after its ref count has gone to 0.
+struct HmacSha512ExpandedKey {
+    // inner represents the actual HMAC state from SymCrypt.
+    inner: symcrypt_sys::SYMCRYPT_HMAC_SHA512_EXPANDED_KEY,
 
-// Since HmacSha512ExpandedKey can be referenced multiple times, HmacSha512ExpandedKey must be ref counted and there needs to be a separate drop()
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    // This prevents the struct from implementing the Unpin trait, enforcing that any
+    // references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
+impl HmacSha512ExpandedKey {
+    fn new(key: &[u8]) -> Result<Pin<Box<Self>>, SymCryptError> {
+        let mut expanded_key = Box::pin(HmacSha512ExpandedKey {
+            inner: symcrypt_sys::SYMCRYPT_HMAC_SHA512_EXPANDED_KEY::default(),
+            _pinned: PhantomPinned,
+        });
+
+        unsafe {
+            // SAFETY: FFI calls
+            match symcrypt_sys::SymCryptHmacSha512ExpandKey(
+                &mut expanded_key.as_mut().get_unchecked_mut().inner,
+                key.as_ptr(),
+                key.len() as symcrypt_sys::SIZE_T,
+            ) {
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(expanded_key),
+                err => Err(err.into()),
+            }
+        }
+    }
+
+    /// Safe method to access the inner state immutably.
+    fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_HMAC_SHA512_EXPANDED_KEY {
+        &self.inner as *const _
+    }
+}
+
+// Since HmacSha512ExpandedKey can be referenced multiple times, HmacSha512ExpandedKey must be ref counted and there needs to be a separate drop().
 impl Drop for HmacSha512ExpandedKey {
     fn drop(&mut self) {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.0) as *mut c_void,
-                mem::size_of_val(&mut self.0) as symcrypt_sys::SIZE_T,
+                ptr::addr_of_mut!(self.inner) as *mut c_void,
+                mem::size_of_val(&mut self.inner) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
-/// `HmacSha512State` is a struct that represents a stateful Hmac using SHA512 and implements the [`HmacState`] trait.
+/// `HmacSha512State` is a struct that represents a stateful HMAC using SHA512 and implements the [`HmacState`] trait.
 pub struct HmacSha512State {
     // SymCrypt expects the address for its structs to stay static through the struct's lifetime to guarantee that structs are not memcpy'd as
     // doing so would lead to use-after-free and inconsistent states.
@@ -869,48 +963,66 @@ pub struct HmacSha512State {
     // Using an `HmacSha512Inner` state that is Pin<Box<>>'d. Memory allocation is not handled by SymCrypt and Self is moved
     // around when returning from `HmacSha512State::new()`. Box<> heap allocates the memory and ensures that it does not move
     // within its lifetime.
-    inner: Pin<Box<HmacSha512Inner>>,
-}
-struct HmacSha512Inner {
-    state: symcrypt_sys::SYMCRYPT_HMAC_SHA512_STATE,
+    state: Pin<Box<HmacSha512Inner>>,
 
-    // Must Arc<> the expanded_key field since it must be ref counted, clones of HmacSha265State will reference the same expanded key. Pin<> on the key
-    // is to ensure that address is not moved throughout the expanded key's lifetime.
-    //
-    // This semantic is not needed for the state field since it is initialized in line with HmacSha512Inner initialization.
-    expanded_key: Pin<Arc<HmacSha512ExpandedKey>>,
+    // Must Arc<> the expanded_key field since it must be ref counted; clones of HmacSha512State will reference the same expanded key.
+    // Arc<T> pointer can move, but its reference T is Pin<Box<>>'d to ensure that the address does not move during its lifetime.
+    key: Arc<Pin<Box<HmacSha512ExpandedKey>>>,
+}
+
+struct HmacSha512Inner {
+    // inner represents the actual HMAC state from SymCrypt.
+    inner: symcrypt_sys::SYMCRYPT_HMAC_SHA512_STATE,
+
+    // _pinned is a marker to ensure that instances of the inner state cannot be moved once pinned.
+    // This prevents the struct from implementing the Unpin trait, enforcing that any
+    // references to this structure remain valid throughout its lifetime.
+    _pinned: PhantomPinned,
+}
+
+impl HmacSha512Inner {
+    fn new() -> Pin<Box<Self>> {
+        Box::pin(HmacSha512Inner {
+            inner: symcrypt_sys::SYMCRYPT_HMAC_SHA512_STATE::default(),
+            _pinned: PhantomPinned,
+        })
+    }
+
+    /// Get a mutable pointer to the inner SymCrypt state.
+    ///
+    /// This is primarily meant to be used while making calls to the underlying SymCrypt APIs.
+    /// This function returns a pointer to pinned data, which means callers must not use the pointer to move the data out of its location.
+    fn get_inner_mut(self: Pin<&mut Self>) -> *mut symcrypt_sys::SYMCRYPT_HMAC_SHA512_STATE {
+        unsafe {
+            // SAFETY: Accessing the inner state of the pinned data.
+            &mut self.get_unchecked_mut().inner as *mut _
+        }
+    }
+
+    /// Safe method to access the inner state immutably.
+    fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_HMAC_SHA512_STATE {
+        &self.inner as *const _
+    }
 }
 
 impl HmacSha512State {
-    /// `new()` takes in a reference to a key and can return a `SymCryptError` that is propagated back to the caller.
+    /// `new()` takes in a `&[u8]` reference to a key and can return a [`SymCryptError`] that is propagated back to the caller.
     pub fn new(key: &[u8]) -> Result<Self, SymCryptError> {
-        let mut expanded_key = Arc::new(HmacSha512ExpandedKey(
-            symcrypt_sys::SYMCRYPT_HMAC_SHA512_EXPANDED_KEY::default(),
-        ));
+        let expanded_key = HmacSha512ExpandedKey::new(key)?;
+        let mut inner_state = HmacSha512Inner::new();
+
         unsafe {
             // SAFETY: FFI calls
-            match symcrypt_sys::SymCryptHmacSha512ExpandKey(
-                // Arc::get_mut() to unbind the Arc<>, &mut (T).0 to get raw pointer for SymCrypt
-                &mut (Arc::get_mut(&mut expanded_key).unwrap()).0,
-                key.as_ptr(),
-                key.len() as symcrypt_sys::SIZE_T,
-            ) {
-                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => {
-                    let mut instance = HmacSha512State {
-                        inner: Box::pin(HmacSha512Inner {
-                            state: symcrypt_sys::SYMCRYPT_HMAC_SHA512_STATE::default(),
-                            expanded_key: Pin::new(expanded_key),
-                        }),
-                    };
-                    symcrypt_sys::SymCryptHmacSha512Init(
-                        &mut instance.inner.state,
-                        &instance.inner.expanded_key.0,
-                    );
-                    Ok(instance)
-                }
-                err => Err(err.into()),
-            }
+            symcrypt_sys::SymCryptHmacSha512Init(
+                inner_state.as_mut().get_inner_mut(),
+                expanded_key.get_inner(),
+            );
         }
+
+        Ok(HmacSha512State {
+            state: inner_state,
+            key: Arc::new(expanded_key),
+        })
     }
 }
 
@@ -921,7 +1033,7 @@ impl HmacState for HmacSha512State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptHmacSha512Append(
-                &mut self.inner.state,
+                self.state.as_mut().get_inner_mut(),
                 data.as_ptr(),
                 data.len() as symcrypt_sys::SIZE_T,
             )
@@ -932,7 +1044,10 @@ impl HmacState for HmacSha512State {
         let mut result = [0u8; SHA512_HMAC_RESULT_SIZE];
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptHmacSha512Result(&mut self.inner.state, result.as_mut_ptr());
+            symcrypt_sys::SymCryptHmacSha512Result(
+                self.state.as_mut().get_inner_mut(),
+                result.as_mut_ptr(),
+            );
         }
         result
     }
@@ -941,20 +1056,18 @@ impl HmacState for HmacSha512State {
 /// Creates a clone of the current `HmacSha512State`. Clone will create a new state field but will reference the same
 /// `expanded_key` of the current `HmacSha512State`.
 impl Clone for HmacSha512State {
-    // Clone will increase the refcount on expanded_key field
+    // Clone will increase the refcount on the expanded_key field.
     fn clone(&self) -> Self {
         let mut new_state = HmacSha512State {
-            inner: Box::pin(HmacSha512Inner {
-                state: symcrypt_sys::SYMCRYPT_HMAC_SHA512_STATE::default(),
-                expanded_key: Pin::clone(&self.inner.expanded_key),
-            }),
+            state: HmacSha512Inner::new(),
+            key: Arc::clone(&self.key), // Clone to increase ref count.
         };
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptHmacSha512StateCopy(
-                &self.inner.state,
-                &self.inner.expanded_key.0,
-                &mut new_state.inner.state,
+                self.state.get_inner(),
+                new_state.key.get_inner(), // Use new ref counted key.
+                new_state.state.as_mut().get_inner_mut(),
             );
         }
         new_state
@@ -966,14 +1079,14 @@ impl Drop for HmacSha512State {
         unsafe {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
-                ptr::addr_of_mut!(self.inner.state) as *mut c_void,
-                mem::size_of_val(&mut self.inner.state) as symcrypt_sys::SIZE_T,
+                self.state.as_mut().get_inner_mut() as *mut c_void,
+                mem::size_of_val(&mut self.state.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
-/// Stateless Hmac function for HmacSha512.
+/// Stateless HMAC function for HmacSha512.
 ///
 /// `key` is a reference to a key.
 ///
@@ -987,18 +1100,15 @@ pub fn hmac_sha512(
     let mut result = [0u8; SHA512_HMAC_RESULT_SIZE];
     unsafe {
         // SAFETY: FFI calls
-        let mut expanded_key = HmacSha512ExpandedKey(
-            // Arc not needed here since this key will not be shared
-            symcrypt_sys::SYMCRYPT_HMAC_SHA512_EXPANDED_KEY::default(),
-        );
+        let mut expanded_key = HmacSha512ExpandedKey::new(key)?;
         match symcrypt_sys::SymCryptHmacSha512ExpandKey(
-            &mut expanded_key.0,
+            &mut expanded_key.as_mut().get_unchecked_mut().inner,
             key.as_ptr(),
             key.len() as symcrypt_sys::SIZE_T,
         ) {
             symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => {
                 symcrypt_sys::SymCryptHmacSha512(
-                    &mut expanded_key.0,
+                    &mut expanded_key.as_mut().get_unchecked_mut().inner,
                     data.as_ptr(),
                     data.len() as symcrypt_sys::SIZE_T,
                     result.as_mut_ptr(),


### PR DESCRIPTION
States that use `Pin<T>` to ensure that states stay consistent throughout their lifetime must also include `PhantomPin` to ensure that the memory does not get moved by rust compiler optimizations. 