### PR TITLE
Fixing pkcs1_decrypt bug

### DIFF
--- a/rust-symcrypt/Cargo.lock
+++ b/rust-symcrypt/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "symcrypt"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hex",
  "lazy_static",

--- a/rust-symcrypt/Cargo.toml
+++ b/rust-symcrypt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "symcrypt"
 authors = ["nnmkhang"]
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 description = "Friendly and Idiomatic Wrappers for SymCrypt"
 edition = "2021"

--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -4,7 +4,7 @@ This crate provides friendly and idiomatic Rust wrappers over [SymCrypt](https:/
 
 This crate has a dependency on `symcrypt-sys`, which utilizes `bindgen` to create Rust/C FFI bindings.
 
-**`symcrypt` version `0.3.0` is based off of `SymCrypt v103.4.2`.**. You must use a version that is greater than or equal to `SymCrypt v103.4.2`. 
+**`symcrypt` version `0.4.0` is based off of `SymCrypt v103.4.2`.**. You must use a version that is greater than or equal to `SymCrypt v103.4.2`. 
 
 To view a detailed list of changes please see the [releases page](https://github.com/microsoft/rust-symcrypt/releases/).
 
@@ -108,7 +108,7 @@ add symcrypt to your `Cargo.toml` file.
 
 ```cargo
 [dependencies]
-symcrypt = "0.3.0"
+symcrypt = "0.4.0"
 hex = "0.4.3"
 ```
 

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -36,7 +36,8 @@
 //!
 //! ```rust
 //! use symcrypt::rsa::{RsaKey, RsaKeyUsage};
-//!
+//! use symcrypt::errors::SymCryptError;
+//! 
 //! // Generate key pair.
 //! let key_pair = RsaKey::generate_key_pair(2048, None, RsaKeyUsage::SignAndEncrypt).unwrap();
 //!
@@ -52,7 +53,7 @@
 //! let res = key_pair.pkcs1_decrypt(&encrypted_message, &mut plaintext_buffer, &mut result_size);
 //!
 //! // Check if decryption was successful.
-//! assert_eq!(res, symcrypt::SymCryptError::NoError);
+//! assert_eq!(res, SymCryptError::NoError);
 //!
 //! // Truncate buffer to the size of the decrypted message.
 //! plaintext_buffer.truncate(result_size as usize);
@@ -116,7 +117,7 @@ impl RsaKey {
     /// This buffer will be randomized before `pcks1_decrypt` is called, you must extract your result from the buffer via the `result_size` parameter if the operation is successful.
     /// The size of the buffer should should be large enough to store the result of the decrypted message, if the buffer is to small, this function will return a [`SymCryptError::BufferTooSmall`].
     ///
-    /// `result_size` is a `&mut u64` representing the size of the decrypted message. This value will be set to the size of the decrypted message if the operation is successful.
+    /// `result_size` is a `&mut usize` representing the size of the decrypted message. This value will be set to the size of the decrypted message if the operation is successful.
     ///
     /// This function will always return a `SymCryptError`, caller must check the return value to determine if the decryption was successful before using the `plaintext_buffer` or `result_size`.
     #[cfg(feature = "pkcs1-encrypt-decrypt")]
@@ -124,11 +125,15 @@ impl RsaKey {
         &self,
         encrypted_message: &[u8],
         plaintext_buffer: &mut [u8],
-        result_size: &mut u64,
+        result_size: &mut usize,
     ) -> SymCryptError {
         symcrypt_random(plaintext_buffer);
-        unsafe {
-            // SAFETY: FFI calls
+
+        // Create a local SIZE_T variable to hold the result size
+        let mut internal_result_size: symcrypt_sys::SIZE_T = 0;
+
+        let error = unsafe {
+            // SAFETY: FFI call with appropriate type casting
             symcrypt_sys::SymCryptRsaPkcs1Decrypt(
                 self.inner(),
                 encrypted_message.as_ptr(),
@@ -137,10 +142,13 @@ impl RsaKey {
                 0, // No flags can be set
                 plaintext_buffer.as_mut_ptr(),
                 plaintext_buffer.len() as symcrypt_sys::SIZE_T,
-                result_size,
+                &mut internal_result_size as *mut symcrypt_sys::SIZE_T,
             )
-            .into()
-        }
+        };
+        // Convert internal_result_size to usize and assign it to result_size
+        *result_size = internal_result_size as usize;
+
+        error.into()
     }
 
     /// `pkcs1_verify()` returns a [`SymCryptError`] if the signature verification fails and `Ok(())` if the verification is successful.
@@ -267,7 +275,7 @@ mod tests {
         let res =
             key_pair.pkcs1_decrypt(&encrypted_message, &mut plaintext_buffer, &mut result_size);
         assert_eq!(res, SymCryptError::NoError);
-        assert_eq!(result_size, message.len() as u64);
+        assert_eq!(result_size, message.len() as usize);
         assert_eq!(plaintext_buffer.len(), 100);
         plaintext_buffer.truncate(result_size as usize);
         assert_eq!(plaintext_buffer, message);


### PR DESCRIPTION
Fixing bug that breaks `pkcs1_decrypt` for Linux.

Breaking change:
- Updating function signature for `pkcs1_decrypt` from `u64` to `usize` to match the bindings for windows and Linux. 
- Updating to 0.4.0 since this is a breaking change. 
- This should only affect users that are on `0.3.0` and are using `pkcs1_decrypt` on Linux, otherwise no changes.

```
pub fn pkcs1_decrypt(
        &self,
        encrypted_message: &[u8],
        plaintext_buffer: &mut [u8],
        result_size: &mut usize,  <---- was previously result_size: &mut u64 
    ) -> SymCryptError {
```