### PR TITLE
Updating rust-symcrypt version to 0.5

### DIFF
--- a/rust-symcrypt/Cargo.lock
+++ b/rust-symcrypt/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "symcrypt"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "symcrypt-sys"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "libc",
 ]

--- a/rust-symcrypt/Cargo.toml
+++ b/rust-symcrypt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "symcrypt"
 authors = ["nnmkhang"]
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 description = "Friendly and Idiomatic Wrappers for SymCrypt"
 edition = "2021"
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 # uses '../symcrypt-sys' when compiled locally, and uses
 # crates.io versioning when published
-symcrypt-sys = {path = "../symcrypt-sys", version = "0.3.0"}
+symcrypt-sys = {path = "../symcrypt-sys", version = "0.4.0"}
 libc = "0.2.0"
 lazy_static = "1.4.0"
 

--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -121,11 +121,10 @@ include symcrypt in your code
 ```rust
 use symcrypt::hash::sha256; 
 use hex;
-fn main() {
-    let data = hex::decode("641ec2cf711e").unwrap();
-    let expected: &str = "cfdbd6c9acf9842ce04e8e6a0421838f858559cf22d2ea8a38bd07d5e4692233";
 
-    let result = sha256(&data);
-    assert_eq!(hex::encode(result), expected);
-}
+let data = hex::decode("641ec2cf711e").unwrap();
+let expected: &str = "cfdbd6c9acf9842ce04e8e6a0421838f858559cf22d2ea8a38bd07d5e4692233";
+
+let result = sha256(&data);
+assert_eq!(hex::encode(result), expected);
 ```

--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -4,7 +4,7 @@ This crate provides friendly and idiomatic Rust wrappers over [SymCrypt](https:/
 
 This crate has a dependency on `symcrypt-sys`, which utilizes `bindgen` to create Rust/C FFI bindings.
 
-**`symcrypt` version `0.4.0` is based off of `SymCrypt v103.4.2`.**. You must use a version that is greater than or equal to `SymCrypt v103.4.2`. 
+**`symcrypt` version `0.5.0` is based off of `SymCrypt v103.4.2`.**. You must use a version that is greater than or equal to `SymCrypt v103.4.2`. 
 
 To view a detailed list of changes please see the [releases page](https://github.com/microsoft/rust-symcrypt/releases/).
 
@@ -50,7 +50,7 @@ Encryption:
 
 ECC:
 - ECDH Secret Agreement ( NistP256, NistP384, NistP521, Curve25519)
-- ECDSA Sign / Verify ( NistP256, NistP384 )
+- ECDSA Sign / Verify ( NistP256, NistP384, NistP521 )
 
 RSA: 
 - PKCS1 ( Sign, Verify, Encrypt, Decrypt )
@@ -112,7 +112,7 @@ add symcrypt to your `Cargo.toml` file.
 
 ```cargo
 [dependencies]
-symcrypt = "0.4.0"
+symcrypt = "0.5.0"
 hex = "0.4.3"
 ```
 

--- a/rust-symcrypt/src/cipher/cbc.rs
+++ b/rust-symcrypt/src/cipher/cbc.rs
@@ -459,7 +459,7 @@ pub mod test {
 
         assert_eq!(buffer, expected_ciphertext);
     }
-    
+
     #[test]
     fn test_aes_expanded_key_multithreaded_encryption() {
         // AES key and IV

--- a/rust-symcrypt/src/cipher/cbc.rs
+++ b/rust-symcrypt/src/cipher/cbc.rs
@@ -200,6 +200,8 @@ pub mod test {
     use crate::cipher::AES_BLOCK_SIZE;
     use hex;
     use std::convert::TryInto;
+    use std::sync::Arc;
+    use std::thread;
 
     #[test]
     fn test_invalid_block_size() {
@@ -456,5 +458,59 @@ pub mod test {
         }
 
         assert_eq!(buffer, expected_ciphertext);
+    }
+    
+    #[test]
+    fn test_aes_expanded_key_multithreaded_encryption() {
+        // AES key and IV
+        let key_hex = "5d98398b5e3b98d87e07ecf1332df4ac";
+        let iv_hex = "db22065fb9302c4445151adc91310797";
+
+        // Plaintext and expected ciphertext
+        let plaintext_hex = "4831f8d1a92cf167a444ccae8d90158dfc55c9a0742019e642116bbaa87aa205";
+        let expected_ciphertext_hex =
+            "f03f86e1a6f1e23e70af3f3ab3b777fd43103f2e7a6fc245a3656799176a2611";
+
+        // Decode hex data into byte arrays
+        let key = hex::decode(key_hex).unwrap();
+        let iv: [u8; 16] = hex::decode(iv_hex).unwrap().try_into().unwrap();
+        let plaintext = hex::decode(plaintext_hex).unwrap();
+        let expected_ciphertext = hex::decode(expected_ciphertext_hex).unwrap();
+
+        // Create an AES expanded key and wrap it in Arc for thread-safe sharing
+        let aes_cbc = Arc::new(AesExpandedKey::new(&key).unwrap());
+
+        // Spawn two threads to perform encryption
+        let mut handles = vec![];
+        for i in 0..2 {
+            let aes_cbc = Arc::clone(&aes_cbc);
+            let iv = iv.clone();
+            let plaintext = plaintext.clone();
+            let expected_ciphertext = expected_ciphertext.clone();
+
+            let handle = thread::spawn(move || {
+                let mut chaining_value = iv;
+                let mut ciphertext = vec![0u8; plaintext.len()];
+
+                // Perform encryption
+                aes_cbc
+                    .aes_cbc_encrypt(&mut chaining_value, &plaintext, &mut ciphertext)
+                    .unwrap();
+
+                // Check that the encryption result matches the expected ciphertext
+                assert_eq!(
+                    ciphertext, expected_ciphertext,
+                    "Thread {}: Encryption did not match expected output.",
+                    i
+                );
+            });
+
+            handles.push(handle);
+        }
+
+        // Wait for both threads to complete
+        for handle in handles {
+            handle.join().expect("Thread panicked");
+        }
     }
 }

--- a/rust-symcrypt/src/cipher/mod.rs
+++ b/rust-symcrypt/src/cipher/mod.rs
@@ -77,6 +77,7 @@ impl Clone for AesExpandedKey {
     }
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
 impl AesExpandedKey {
     /// `new()` returns an `AesExpandedKey` or a [`SymCryptError`] if the operation fails.
     pub fn new(key: &[u8]) -> Result<Self, SymCryptError> {

--- a/rust-symcrypt/src/cipher/mod.rs
+++ b/rust-symcrypt/src/cipher/mod.rs
@@ -80,9 +80,9 @@ impl AesExpandedKey {
                 key.as_ptr(),
                 key.len() as symcrypt_sys::SIZE_T,
             ) {
-                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(AesExpandedKey {
-                    expanded_key,
-                }),
+                symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => {
+                    Ok(AesExpandedKey { expanded_key })
+                }
                 err => Err(err.into()),
             }
         }
@@ -93,7 +93,7 @@ impl AesExpandedKey {
     }
 }
 
-// No custom Send / Sync impl. needed for AesInnerKey and AesExpandedKey and BlockCipherType since the 
+// No custom Send / Sync impl. needed for AesInnerKey and AesExpandedKey and BlockCipherType since the
 // underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
 unsafe impl Send for AesInnerKey {}
 unsafe impl Sync for AesInnerKey {}

--- a/rust-symcrypt/src/cipher/mod.rs
+++ b/rust-symcrypt/src/cipher/mod.rs
@@ -14,7 +14,6 @@
 //! let key = hex::decode("5d98398b5e3b98d87e07ecf1332df4ac").unwrap();
 //! let aes_key = AesExpandedKey::new(&key).unwrap();
 //!
-//! let aes_key_clone = aes_key.clone();
 //! ```
 //!
 use crate::errors::SymCryptError;
@@ -23,7 +22,6 @@ use symcrypt_sys;
 
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::sync::Arc;
 
 // export ciphers
 pub mod cbc;
@@ -66,18 +64,9 @@ impl AesInnerKey {
 /// `AesExpandedKey` is a struct that represents an expanded AES key. This struct holds no state and is used to encrypt and decrypt data.
 pub struct AesExpandedKey {
     // Owned expanded key, this has no state, other calls will take reference to this key.
-    expanded_key: Arc<Pin<Box<AesInnerKey>>>,
+    expanded_key: Pin<Box<AesInnerKey>>,
 }
 
-impl Clone for AesExpandedKey {
-    fn clone(&self) -> Self {
-        AesExpandedKey {
-            expanded_key: Arc::clone(&self.expanded_key),
-        }
-    }
-}
-
-#[allow(clippy::arc_with_non_send_sync)]
 impl AesExpandedKey {
     /// `new()` returns an `AesExpandedKey` or a [`SymCryptError`] if the operation fails.
     pub fn new(key: &[u8]) -> Result<Self, SymCryptError> {
@@ -92,7 +81,7 @@ impl AesExpandedKey {
                 key.len() as symcrypt_sys::SIZE_T,
             ) {
                 symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(AesExpandedKey {
-                    expanded_key: Arc::new(expanded_key),
+                    expanded_key,
                 }),
                 err => Err(err.into()),
             }
@@ -104,13 +93,14 @@ impl AesExpandedKey {
     }
 }
 
-unsafe impl Send for BlockCipherType {
-    // TODO: discuss send/sync implementation for rustls.
-}
-
-unsafe impl Sync for BlockCipherType {
-    // TODO: discuss send/sync implementation for rustls.
-}
+// No custom Send / Sync impl. needed for AesInnerKey and AesExpandedKey and BlockCipherType since the 
+// underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
+unsafe impl Send for AesInnerKey {}
+unsafe impl Sync for AesInnerKey {}
+unsafe impl Send for AesExpandedKey {}
+unsafe impl Sync for AesExpandedKey {}
+unsafe impl Send for BlockCipherType {}
+unsafe impl Sync for BlockCipherType {}
 
 pub(crate) fn convert_cipher(cipher: BlockCipherType) -> symcrypt_sys::PCSYMCRYPT_BLOCKCIPHER {
     match cipher {

--- a/rust-symcrypt/src/ecc/mod.rs
+++ b/rust-symcrypt/src/ecc/mod.rs
@@ -111,14 +111,6 @@ impl Drop for InnerEcKey {
 // InnerEcCurve is a wrapper around symcrypt_sys::PSYMCRYPT_ECURVE.
 pub(crate) struct InnerEcCurve(pub(crate) symcrypt_sys::PSYMCRYPT_ECURVE);
 
-unsafe impl Send for InnerEcCurve {
-    // TODO: Discuss send/sync for rustls
-}
-
-unsafe impl Sync for InnerEcCurve {
-    // TODO: Discuss send/sync for rustls
-}
-
 // Must drop EcCurve after EcKey is dropped, will always be the case since EcCurve is static.
 impl Drop for InnerEcCurve {
     fn drop(&mut self) {
@@ -167,14 +159,6 @@ pub struct EcKey {
     curve_type: CurveType,
     ec_key_usage: EcKeyUsage,
     has_private_key: bool,
-}
-
-unsafe impl Send for EcKey {
-    // TODO: Discuss send/sync for rustls
-}
-
-unsafe impl Sync for EcKey {
-    // TODO: Discuss send/sync for rustls
 }
 
 impl EcKey {
@@ -423,6 +407,13 @@ impl EcKey {
         }
     }
 }
+
+// No custom Send / Sync impl. needed for EcKey and InnerEcCurve since the 
+// underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
+unsafe impl Send for InnerEcCurve {}
+unsafe impl Sync for InnerEcCurve {}
+unsafe impl Send for EcKey {}
+unsafe impl Sync for EcKey {}
 
 // Curves can be re-used across EcKey calls, creating static references to save on allocations and increase perf.
 lazy_static! {

--- a/rust-symcrypt/src/ecc/mod.rs
+++ b/rust-symcrypt/src/ecc/mod.rs
@@ -408,7 +408,7 @@ impl EcKey {
     }
 }
 
-// No custom Send / Sync impl. needed for EcKey and InnerEcCurve since the 
+// No custom Send / Sync impl. needed for EcKey and InnerEcCurve since the
 // underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
 unsafe impl Send for InnerEcCurve {}
 unsafe impl Sync for InnerEcCurve {}

--- a/rust-symcrypt/src/gcm.rs
+++ b/rust-symcrypt/src/gcm.rs
@@ -166,7 +166,8 @@ impl GcmExpandedKey {
     /// `buffer` is a `&mut [u8]` that contains the plain text data to be encrypted. After the encryption has been completed,
     /// `buffer` will be over-written to contain the cipher text data.
     ///
-    /// `tag` is a `&mut [u8]` which is the buffer where the resulting tag will be written to.
+    /// `tag` is a `&mut [u8]` which is the buffer where the resulting tag will be written to. Tag size must be 12, 13, 14, 15, 16 per SP800-38D.
+    /// Tag sizes of 4 and 8 are not supported.
     pub fn encrypt_in_place(
         &self,
         nonce: &[u8; 12],
@@ -269,12 +270,13 @@ fn gcm_expand_key(
 ///
 /// `nonce` is a `&[u8; 12]`  that represents a nonce array.
 ///
-/// `auth_data` is an optional `$[u8]` that can be provided, if you do not wish to provide
+/// `auth_data` is an optional `&[u8]` that can be provided, if you do not wish to provide
 /// any auth data, input an empty array.
 ///
 /// `data` is a `&[u8]` that represents the data array to be encrypted
 ///
-/// `tag` is a `&[u8]`that represents the tag buffer, the size of the tag buffer will be checked.
+/// `tag` is a `&[u8]` that represents the tag buffer, the size of the tag buffer will be checked and must be 12, 13, 14, 15, 16 per SP800-38D.
+/// Tag sizes of 4 and 8 are not supported.
 pub fn validate_gcm_parameters(
     cipher: BlockCipherType,
     nonce: &[u8; 12], // GCM nonce length must be 12 bytes

--- a/rust-symcrypt/src/gcm.rs
+++ b/rust-symcrypt/src/gcm.rs
@@ -149,7 +149,7 @@ impl GcmExpandedKey {
             convert_cipher(cipher),
         )?;
         let gcm_expanded_key = GcmExpandedKey {
-            expanded_key: expanded_key,
+            expanded_key,
             key_length: key.len(),
         };
         Ok(gcm_expanded_key)

--- a/rust-symcrypt/src/gcm.rs
+++ b/rust-symcrypt/src/gcm.rs
@@ -221,13 +221,10 @@ impl GcmExpandedKey {
     }
 }
 
-unsafe impl Send for GcmExpandedKey {
-    // TODO: Configure send/sync traits
-}
-
-unsafe impl Sync for GcmExpandedKey {
-    // TODO: Configure send/sync traits
-}
+// No custom Send / Sync impl. needed for GcmExpandedKey and GcmExpandedKey since the 
+// underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
+unsafe impl Send for GcmExpandedKey {}
+unsafe impl Sync for GcmExpandedKey {}
 
 // Internal function to expand the SymCrypt Gcm Key.
 fn gcm_expand_key(

--- a/rust-symcrypt/src/gcm.rs
+++ b/rust-symcrypt/src/gcm.rs
@@ -221,7 +221,7 @@ impl GcmExpandedKey {
     }
 }
 
-// No custom Send / Sync impl. needed for GcmExpandedKey and GcmExpandedKey since the 
+// No custom Send / Sync impl. needed for GcmExpandedKey since the
 // underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
 unsafe impl Send for GcmExpandedKey {}
 unsafe impl Sync for GcmExpandedKey {}

--- a/rust-symcrypt/src/gcm.rs
+++ b/rust-symcrypt/src/gcm.rs
@@ -136,7 +136,9 @@ impl Drop for GcmInnerKey {
 /// This is for scenarios such as encrypting over a stream of data; allocating and copying data from a return will be costly performance wise.
 impl GcmExpandedKey {
     /// `new` takes in a reference to a key and a [`BlockCipherType`] and returns an expanded key that is Pin<Box<>>'d.
+    ///
     /// This function can fail and will propagate the error back to the caller. This call will fail if the wrong key size is provided.
+    ///
     /// The only accepted Cipher for GCM is [`BlockCipherType::AesBlock`]
     pub fn new(key: &[u8], cipher: BlockCipherType) -> Result<Self, SymCryptError> {
         symcrypt_init();
@@ -155,9 +157,16 @@ impl GcmExpandedKey {
         Ok(gcm_expanded_key)
     }
 
-    /// `encrypt_in_place` takes in a `&mut buffer` that has the plain text data to be encrypted. After the encryption has been completed,
-    /// the `buffer` will be over-written to contain the cipher text data. `encrypt_in_place` will also take in `tag` which is
-    /// a `&mut buffer` where the resulting tag will be written to.
+    /// `encrypt_in_place` performs an in-place encryption on the `&mut buffer` that is passed. This call cannot fail.
+    ///
+    /// `nonce` is a `&[u8; 12]` that is used as the nonce for the encryption.
+    ///
+    /// `auth_data` is an optional `&[u8]` that can be provided, if you do not wish to provide any auth data, input an empty array.
+    ///
+    /// `buffer` is a `&mut [u8]` that contains the plain text data to be encrypted. After the encryption has been completed,
+    /// `buffer` will be over-written to contain the cipher text data.
+    ///
+    /// `tag` is a `&mut [u8]` which is the buffer where the resulting tag will be written to.
     pub fn encrypt_in_place(
         &self,
         nonce: &[u8; 12],
@@ -183,10 +192,18 @@ impl GcmExpandedKey {
         }
     }
 
-    /// `decrypt_in_place` takes in a `&mut buffer` that has the cipher text to be decrypted. After the decryption has been completed,
-    /// the `buffer` will be over-written to contain the plain text data. `decrypt_in_place` will also take in a `tag` which will
-    /// verify the cipher text has not been tampered with. `decrypt_in_place` can fail and you must check the result before using the
-    /// value stored in `buffer`.
+    /// `decrypt_in_place` performs an in-place decryption on the `&mut buffer` that is passed. This call can fail and the caller must check the result.
+    ///
+    /// `nonce` is a `&[u8; 12]` that is used as the nonce for the decryption. It must match the nonce used during encryption.
+    ///
+    /// `auth_data` is an optional `&[u8]` that can be provided. If you do not wish to provide any auth data, input an empty array.
+    ///
+    /// `buffer` is a `&mut [u8]` that contains the cipher text data to be decrypted. After the decryption has been completed,
+    /// `buffer` will be over-written to contain the plain text data.
+    ///
+    /// `tag` is a `&[u8]` that contains the authentication tag generated during encryption. This is used to verify the integrity of the cipher text.
+    ///
+    /// If decryption succeeds, the function will return `Ok(())`, and `buffer` will contain the plain text. If it fails, an error of type `SymCryptError` will be returned.
     pub fn decrypt_in_place(
         &self,
         nonce: &[u8; 12],
@@ -250,14 +267,14 @@ fn gcm_expand_key(
 ///
 /// `cipher` will only accept [`BlockCipherType::AesBlock`]
 ///
-/// `nonce` is a reference to a nonce array that must be 12 bytes.
+/// `nonce` is a `&[u8; 12]`  that represents a nonce array.
 ///
-/// `auth_data` is an optional parameter that can be provided, if you do not wish to provide
+/// `auth_data` is an optional `$[u8]` that can be provided, if you do not wish to provide
 /// any auth data, input an empty array.
 ///
-/// `data` is a reference to a data array to be encrypted
+/// `data` is a `&[u8]` that represents the data array to be encrypted
 ///
-/// `tag` is a reference to your tag buffer, the size of the tag buffer will be checked.
+/// `tag` is a `&[u8]`that represents the tag buffer, the size of the tag buffer will be checked.
 pub fn validate_gcm_parameters(
     cipher: BlockCipherType,
     nonce: &[u8; 12], // GCM nonce length must be 12 bytes

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -110,10 +110,9 @@ pub enum HashAlgorithm {
     Sha3_512,
 }
 
-#[allow(clippy::wrong_self_convention)]
 impl HashAlgorithm {
     // Returns the symcrypt_sys::_SYMCRYPT_OID for calling underlying SymCrypt functions, hidden from the user.
-    pub(crate) fn to_oid_list(&self) -> &[symcrypt_sys::_SYMCRYPT_OID] {
+    pub(crate) fn get_oid_list(&self) -> &[symcrypt_sys::_SYMCRYPT_OID] {
         unsafe {
             match self {
                 #[cfg(feature = "md5")]
@@ -131,7 +130,7 @@ impl HashAlgorithm {
     }
 
     /// Returns the symcrypt_sys::PCSYMCRYPT_HASH for calling underlying SymCrypt functions, hidden from the user.
-    pub(crate) fn to_symcrypt_hash(&self) -> symcrypt_sys::PCSYMCRYPT_HASH {
+    pub(crate) fn get_symcrypt_hash(&self) -> symcrypt_sys::PCSYMCRYPT_HASH {
         unsafe {
             match self {
                 #[cfg(feature = "md5")]

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -110,6 +110,7 @@ pub enum HashAlgorithm {
     Sha3_512,
 }
 
+#[allow(clippy::wrong_self_convention)]
 impl HashAlgorithm {
     // Returns the symcrypt_sys::_SYMCRYPT_OID for calling underlying SymCrypt functions, hidden from the user.
     pub(crate) fn to_oid_list(&self) -> &[symcrypt_sys::_SYMCRYPT_OID] {
@@ -230,6 +231,13 @@ impl Md5State {
     // Safe method to access the inner state immutably
     pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_MD5_STATE {
         &self.0.as_ref().get_ref().inner as *const _
+    }
+}
+
+#[cfg(feature = "md5")]
+impl Default for Md5State {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -361,6 +369,13 @@ impl Sha1State {
 }
 
 #[cfg(feature = "sha1")]
+impl Default for Sha1State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "sha1")]
 impl HashState for Sha1State {
     type Result = [u8; SHA1_RESULT_SIZE];
 
@@ -484,6 +499,12 @@ impl Sha256State {
     }
 }
 
+impl Default for Sha256State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HashState for Sha256State {
     type Result = [u8; SHA256_RESULT_SIZE];
 
@@ -601,6 +622,12 @@ impl Sha384State {
     // Safe method to access the inner state immutably
     pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA384_STATE {
         &self.0.as_ref().get_ref().inner as *const _
+    }
+}
+
+impl Default for Sha384State {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -724,6 +751,12 @@ impl Sha512State {
     }
 }
 
+impl Default for Sha512State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HashState for Sha512State {
     type Result = [u8; SHA512_RESULT_SIZE];
 
@@ -841,6 +874,12 @@ impl Sha3_256State {
     // Safe method to access the inner state immutably
     pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA3_256_STATE {
         &self.0.as_ref().get_ref().inner as *const _
+    }
+}
+
+impl Default for Sha3_256State {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -964,6 +1003,12 @@ impl Sha3_384State {
     }
 }
 
+impl Default for Sha3_384State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HashState for Sha3_384State {
     type Result = [u8; SHA3_384_RESULT_SIZE];
 
@@ -1081,6 +1126,12 @@ impl Sha3_512State {
     // Safe method to access the inner state immutably
     pub(crate) fn get_inner(&self) -> *const symcrypt_sys::SYMCRYPT_SHA3_512_STATE {
         &self.0.as_ref().get_ref().inner as *const _
+    }
+}
+
+impl Default for Sha3_512State {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/rust-symcrypt/src/hkdf.rs
+++ b/rust-symcrypt/src/hkdf.rs
@@ -77,7 +77,7 @@ pub fn hkdf(
             hmac_res.len() as symcrypt_sys::SIZE_T,
         ) {
             symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(hmac_res),
-            err => return Err(SymCryptError::from(err)),
+            err => Err(SymCryptError::from(err)),
         }
     }
 }

--- a/rust-symcrypt/src/hmac.rs
+++ b/rust-symcrypt/src/hmac.rs
@@ -346,6 +346,7 @@ impl Drop for HmacMd5State {
     }
 }
 
+// Ignoring Clippy: Mutability is required for internal operations on the expanded key
 #[allow(clippy::unnecessary_mut_passed)]
 #[cfg(feature = "md5")]
 /// Stateless HMAC function for HmacMd5.
@@ -573,6 +574,7 @@ impl Drop for HmacSha1State {
     }
 }
 
+// Ignoring Clippy: Mutability is required for internal operations on the expanded key
 #[cfg(feature = "sha1")]
 #[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha1.
@@ -794,6 +796,7 @@ impl Drop for HmacSha256State {
     }
 }
 
+// Ignoring Clippy: Mutability is required for internal operations on the expanded key
 #[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha256.
 ///
@@ -1018,6 +1021,7 @@ impl Drop for HmacSha384State {
     }
 }
 
+// Ignoring Clippy: Mutability is required for internal operations on the expanded key
 #[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha384.
 ///
@@ -1237,6 +1241,7 @@ impl Drop for HmacSha512State {
     }
 }
 
+// Ignoring Clippy: Mutability is required for internal operations on the expanded key
 #[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha512.
 ///

--- a/rust-symcrypt/src/hmac.rs
+++ b/rust-symcrypt/src/hmac.rs
@@ -707,13 +707,10 @@ impl HmacSha256Inner {
     }
 }
 
-unsafe impl Send for HmacSha256Inner {
-    // TODO: discuss send/sync implementation for rustls
-}
-
-unsafe impl Sync for HmacSha256Inner {
-    // TODO: discuss send/sync implementation for rustls
-}
+// No custom Send / Sync impl. needed for HmacSha256Inner since the
+// underlying data is a pointer to an owned SymCrypt HmacState that is follows Rust's ownership rules
+unsafe impl Send for HmacSha256Inner {}
+unsafe impl Sync for HmacSha256Inner {}
 
 impl HmacSha256State {
     /// `new()` takes in a `&[u8]` reference to a key and can return a [`SymCryptError`] that is propagated back to the caller.
@@ -934,13 +931,10 @@ impl HmacSha384Inner {
     }
 }
 
-unsafe impl Send for HmacSha384Inner {
-    // TODO: discuss send/sync implementation for rustls
-}
-
-unsafe impl Sync for HmacSha384Inner {
-    // TODO: discuss send/sync implementation for rustls
-}
+// No custom Send / Sync impl. needed for HmacSha384Inner since the
+// underlying data is a pointer to an owned SymCrypt HmacState that is follows Rust's ownership rules
+unsafe impl Send for HmacSha384Inner {}
+unsafe impl Sync for HmacSha384Inner {}
 
 impl HmacSha384State {
     /// `new()` takes in a `&[u8]` reference to a key and can return a [`SymCryptError`] that is propagated back to the caller.

--- a/rust-symcrypt/src/hmac.rs
+++ b/rust-symcrypt/src/hmac.rs
@@ -106,7 +106,7 @@ pub enum HmacAlgorithm {
 
 impl HmacAlgorithm {
     /// Returns the symcrypt_sys::PCSYMCRYPT_MAC for calling underlying SymCrypt functions, hidden from the user.   
-    pub(crate) fn to_symcrypt_hmac_algorithm(&self) -> symcrypt_sys::PCSYMCRYPT_MAC {
+    pub(crate) fn to_symcrypt_hmac_algorithm(self) -> symcrypt_sys::PCSYMCRYPT_MAC {
         match self {
             #[cfg(feature = "md5")]
             HmacAlgorithm::HmacMd5 => unsafe { symcrypt_sys::SymCryptHmacMd5Algorithm }, // UNSAFE FFI calls
@@ -200,7 +200,7 @@ impl Drop for HmacMd5ExpandedKey {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 ptr::addr_of_mut!(self.inner) as *mut c_void,
-                mem::size_of_val(&mut self.inner) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.inner) as symcrypt_sys::SIZE_T,
             );
         }
     }
@@ -340,12 +340,13 @@ impl Drop for HmacMd5State {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 self.state.as_mut().get_inner_mut() as *mut c_void,
-                mem::size_of_val(&mut self.state.get_inner()) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.state.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
+#[allow(clippy::unnecessary_mut_passed)]
 #[cfg(feature = "md5")]
 /// Stateless HMAC function for HmacMd5.
 ///
@@ -427,7 +428,7 @@ impl Drop for HmacSha1ExpandedKey {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 ptr::addr_of_mut!(self.inner) as *mut c_void,
-                mem::size_of_val(&mut self.inner) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.inner) as symcrypt_sys::SIZE_T,
             );
         }
     }
@@ -566,13 +567,14 @@ impl Drop for HmacSha1State {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 self.state.as_mut().get_inner_mut() as *mut c_void,
-                mem::size_of_val(&mut self.state.get_inner()) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.state.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
 #[cfg(feature = "sha1")]
+#[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha1.
 ///
 /// `key` is a reference to a key.
@@ -650,7 +652,7 @@ impl Drop for HmacSha256ExpandedKey {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 ptr::addr_of_mut!(self.inner) as *mut c_void,
-                mem::size_of_val(&mut self.inner) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.inner) as symcrypt_sys::SIZE_T,
             );
         }
     }
@@ -789,12 +791,13 @@ impl Drop for HmacSha256State {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 self.state.as_mut().get_inner_mut() as *mut c_void,
-                mem::size_of_val(&mut self.state.get_inner()) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.state.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
+#[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha256.
 ///
 /// `key` is a reference to a key.
@@ -875,7 +878,7 @@ impl Drop for HmacSha384ExpandedKey {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 ptr::addr_of_mut!(self.inner) as *mut c_void,
-                mem::size_of_val(&mut self.inner) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.inner) as symcrypt_sys::SIZE_T,
             );
         }
     }
@@ -1015,12 +1018,13 @@ impl Drop for HmacSha384State {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 self.state.as_mut().get_inner_mut() as *mut c_void,
-                mem::size_of_val(&mut self.state.get_inner()) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.state.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
+#[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha384.
 ///
 /// `key` is a reference to a key.
@@ -1101,7 +1105,7 @@ impl Drop for HmacSha512ExpandedKey {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 ptr::addr_of_mut!(self.inner) as *mut c_void,
-                mem::size_of_val(&mut self.inner) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.inner) as symcrypt_sys::SIZE_T,
             );
         }
     }
@@ -1233,12 +1237,13 @@ impl Drop for HmacSha512State {
             // SAFETY: FFI calls
             symcrypt_sys::SymCryptWipe(
                 self.state.as_mut().get_inner_mut() as *mut c_void,
-                mem::size_of_val(&mut self.state.get_inner()) as symcrypt_sys::SIZE_T,
+                mem::size_of_val(&self.state.get_inner()) as symcrypt_sys::SIZE_T,
             );
         }
     }
 }
 
+#[allow(clippy::unnecessary_mut_passed)]
 /// Stateless HMAC function for HmacSha512.
 ///
 /// `key` is a reference to a key.

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -107,7 +107,7 @@ pub enum RsaKeyUsage {
 
 // to_symcrypt_flag converts the RsaKeyUsage to the corresponding SymCrypt flag and only needed internally.
 impl RsaKeyUsage {
-    pub(crate) fn to_symcrypt_flag(&self) -> symcrypt_sys::UINT32 {
+    pub(crate) fn to_symcrypt_flag(self) -> symcrypt_sys::UINT32 {
         match self {
             RsaKeyUsage::Sign => symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_SIGN,
             RsaKeyUsage::Encrypt => symcrypt_sys::SYMCRYPT_FLAG_RSAKEY_ENCRYPT,
@@ -189,7 +189,7 @@ impl RsaKey {
             ) {
                 symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKey {
                     inner: rsa_key,
-                    rsa_key_usage: rsa_key_usage,
+                    rsa_key_usage,
                     has_private_key: true,
                 }),
                 err => Err(err.into()),
@@ -244,7 +244,7 @@ impl RsaKey {
             ) {
                 symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKey {
                     inner: rsa_key,
-                    rsa_key_usage: rsa_key_usage,
+                    rsa_key_usage,
                     has_private_key: true,
                 }),
                 err => Err(err.into()),
@@ -288,7 +288,7 @@ impl RsaKey {
             ) {
                 symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKey {
                     inner: rsa_key,
-                    rsa_key_usage: rsa_key_usage,
+                    rsa_key_usage,
                     has_private_key: false,
                 }),
                 err => Err(err.into()),
@@ -473,7 +473,7 @@ fn allocate_rsa(
     unsafe {
         // SAFETY: FFI calls
         let result = symcrypt_sys::SymCryptRsakeyAllocate(&rsa_params, 0);
-        if result == ptr::null_mut() {
+        if result.is_null() {
             return Err(SymCryptError::MemoryAllocationFailure);
         }
         Ok(InnerRsaKey(result))

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -82,7 +82,9 @@ impl Drop for InnerRsaKey {
     fn drop(&mut self) {
         unsafe {
             // SAFETY: FFI calls
-            symcrypt_sys::SymCryptRsakeyFree(self.0);
+            if !self.0.is_null() {
+                symcrypt_sys::SymCryptRsakeyFree(self.0);
+            }
         }
     }
 }
@@ -451,7 +453,7 @@ impl RsaKey {
     }
 }
 
-// No custom Send / Sync impl. needed for RsaKey and RsaKeyInner since the 
+// No custom Send / Sync impl. needed for RsaKey and RsaKeyInner since the
 // underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
 unsafe impl Send for RsaKey {}
 unsafe impl Sync for RsaKey {}

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -77,6 +77,10 @@ pub mod pss;
 #[derive(Debug)]
 pub(crate) struct InnerRsaKey(pub(crate) symcrypt_sys::PSYMCRYPT_RSAKEY);
 
+// TODO: Discuss Send/Sync implementation for rustls.
+unsafe impl Send for InnerRsaKey {}
+unsafe impl Sync for InnerRsaKey {}
+
 // Must free inner key rather than the outer struct.
 impl Drop for InnerRsaKey {
     fn drop(&mut self) {
@@ -450,6 +454,10 @@ impl RsaKey {
         self.inner.0
     }
 }
+
+// TODO: Discuss Send/Sync implementation for rustls.
+unsafe impl Send for RsaKey {}
+unsafe impl Sync for RsaKey {}
 
 // Utility function to reduce common RSA allocation call
 fn allocate_rsa(

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -77,10 +77,6 @@ pub mod pss;
 #[derive(Debug)]
 pub(crate) struct InnerRsaKey(pub(crate) symcrypt_sys::PSYMCRYPT_RSAKEY);
 
-// TODO: Discuss Send/Sync implementation for rustls.
-unsafe impl Send for InnerRsaKey {}
-unsafe impl Sync for InnerRsaKey {}
-
 // Must free inner key rather than the outer struct.
 impl Drop for InnerRsaKey {
     fn drop(&mut self) {
@@ -455,9 +451,12 @@ impl RsaKey {
     }
 }
 
-// TODO: Discuss Send/Sync implementation for rustls.
+// No custom Send / Sync impl. needed for RsaKey and RsaKeyInner since the 
+// underlying data is a pointer to a SymCrypt struct that is not modified after it is created.
 unsafe impl Send for RsaKey {}
 unsafe impl Sync for RsaKey {}
+unsafe impl Send for InnerRsaKey {}
+unsafe impl Sync for InnerRsaKey {}
 
 // Utility function to reduce common RSA allocation call
 fn allocate_rsa(

--- a/rust-symcrypt/src/rsa/oaep.rs
+++ b/rust-symcrypt/src/rsa/oaep.rs
@@ -47,7 +47,7 @@ impl RsaKey {
         let mut result_size: symcrypt_sys::SIZE_T = 0;
         let modulus_size = self.get_size_of_modulus();
         let mut decrypted_buffer = vec![0u8; modulus_size as usize];
-        let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+        let hash_algorithm_ptr = hash_algorithm.get_symcrypt_hash();
 
         unsafe {
             // SAFETY: FFI calls
@@ -92,7 +92,7 @@ impl RsaKey {
         let mut result_size: symcrypt_sys::SIZE_T = 0;
         let modulus_size = self.get_size_of_modulus();
         let mut encrypted = vec![0u8; modulus_size as usize];
-        let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+        let hash_algorithm_ptr = hash_algorithm.get_symcrypt_hash();
 
         unsafe {
             // SAFETY: FFI calls

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -75,8 +75,8 @@ impl RsaKey {
     /// `pcks1_sign()` signs a hashed message using the private key of [`RsaKey`] and returns a `Vec<u8>` representing the signature,
     /// or a [`SymCryptError`] if the operation fails.
     ///
-    /// `hashed_message` is a `&[u8]` representing the hashed message to be signed.
-    ///
+    /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
+    /// 
     /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
     ///
     /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
@@ -158,8 +158,8 @@ impl RsaKey {
     ///
     /// Caller must check the return value to determine if the signature is valid before continuing.
     ///
-    /// `hashed_message` is a `&[u8]` representing the hashed message to be verified.
-    ///
+    /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
+    /// 
     /// `signature` is a `&[u8]` representing the signature to be verified.
     ///
     /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -76,7 +76,7 @@ impl RsaKey {
     /// or a [`SymCryptError`] if the operation fails.
     ///
     /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
-    /// 
+    ///
     /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
     ///
     /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
@@ -88,7 +88,7 @@ impl RsaKey {
         let mut result_size = 0;
         let modulus_size = self.get_size_of_modulus();
         let mut signature = vec![0u8; modulus_size as usize];
-        let converted_hash_oids = hash_algorithm.to_oid_list();
+        let converted_hash_oids = hash_algorithm.get_oid_list();
         unsafe {
             // SAFETY: FFI calls
             match symcrypt_sys::SymCryptRsaPkcs1Sign(
@@ -159,7 +159,7 @@ impl RsaKey {
     /// Caller must check the return value to determine if the signature is valid before continuing.
     ///
     /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
-    /// 
+    ///
     /// `signature` is a `&[u8]` representing the signature to be verified.
     ///
     /// `hash_algorithm` is a [`HashAlgorithm`] representing the hash algorithm used to hash the message.
@@ -169,7 +169,7 @@ impl RsaKey {
         signature: &[u8],
         hash_algorithm: HashAlgorithm,
     ) -> Result<(), SymCryptError> {
-        let converted_hash_oids = hash_algorithm.to_oid_list();
+        let converted_hash_oids = hash_algorithm.get_oid_list();
         unsafe {
             // SAFETY: FFI calls
             match symcrypt_sys::SymCryptRsaPkcs1Verify(

--- a/rust-symcrypt/src/rsa/pss.rs
+++ b/rust-symcrypt/src/rsa/pss.rs
@@ -33,8 +33,8 @@ impl RsaKey {
     ///
     /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
     ///  
-    /// `hash_algorithm` is a [`HashAlgorithm`] representing the algorithm used to hash the message.
-    /// 
+    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm used to hash the message.
+    ///
     /// `salt_length` is a `usize` that represents the length of the salt to be used in the PSS signature, this value is typically the length of the hash output.
     ///
     /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.
@@ -47,7 +47,7 @@ impl RsaKey {
         let mut result_size = 0;
         let modulus_size = self.get_size_of_modulus();
         let mut signature = vec![0u8; modulus_size as usize];
-        let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+        let hash_algorithm_ptr = hash_algorithm.get_symcrypt_hash();
 
         unsafe {
             // SAFETY: FFI calls
@@ -90,7 +90,7 @@ impl RsaKey {
         hash_algorithm: HashAlgorithm,
         salt_length: usize,
     ) -> Result<(), SymCryptError> {
-        let hash_algorithm_ptr = hash_algorithm.to_symcrypt_hash();
+        let hash_algorithm_ptr = hash_algorithm.get_symcrypt_hash();
 
         unsafe {
             // SAFETY: FFI calls

--- a/rust-symcrypt/src/rsa/pss.rs
+++ b/rust-symcrypt/src/rsa/pss.rs
@@ -33,8 +33,8 @@ impl RsaKey {
     ///
     /// `hashed_message` is a `&[u8]` that represents the message that has been hashed using the hash algorithm specified in `hash_algorithm`.
     ///  
-    /// `hash_algorithm` is a [`HashAlgorithm`] that represents the hash algorithm used to hash the message.
-    ///
+    /// `hash_algorithm` is a [`HashAlgorithm`] representing the algorithm used to hash the message.
+    /// 
     /// `salt_length` is a `usize` that represents the length of the salt to be used in the PSS signature, this value is typically the length of the hash output.
     ///
     /// This function will fail with [`SymCryptError::InvalidArgument`] if [`RsaKey`] does not have a private key attached.

--- a/symcrypt-sys/Cargo.lock
+++ b/symcrypt-sys/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "symcrypt-sys"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libc",
 ]

--- a/symcrypt-sys/Cargo.toml
+++ b/symcrypt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "symcrypt-sys"
 authors = ["Microsoft"]
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 description = "Rust/C Bindings for SymCrypt"
 edition = "2021"

--- a/symcrypt-sys/README.md
+++ b/symcrypt-sys/README.md
@@ -20,7 +20,7 @@ You must also configure your system to pick up the SymCrypt lib on your machine,
 
 In your `Cargo.toml`
 ```Rust
-symcrypt-sys = "0.3.0"
+symcrypt-sys = "0.4.0"
 ```
 Then you can call the underlying SymCrypt code directly via the FFIs.
 ```Rust


### PR DESCRIPTION
Changes
- Bumped `rust-symcrypt` to version `0.5`
- Bumped `symcrypt-sys` to version `0.4`
- Added Send/Sync implementation for `InnerRsaKey` and `RsaKey` types
- Updated comments around Send/Sync.
- Added `impl Default` for hashing code
- Clippy + cargo fmt

Notes: 
- This version bump 0.5 will include changes for `cbc` as well as `hkdf` that were included on the main branch. 

Breaking change:
- Removing Arc<> from `cbc`. This is only a breaking change on github, cargo versions will be un-affected. 

