### PR TITLE
Fix dangling pointers in rsa::generate_key_pair and rsa::set_key_pair

### DIFF
--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -53,7 +53,7 @@
 //!
 //! let pub_exp = [1, 0, 1];
 //! let public_key = RsaKey::set_public_key(&modulus, &pub_exp, RsaKeyUsage::Sign).unwrap();
-//!    
+//!
 //! // public_key can now be used via pkcs1, pss, or oaep.
 //!
 //! // RsaKey does not have a private key attached.
@@ -158,7 +158,7 @@ impl RsaKey {
     /// `n_bits_mod` represents a `u32` that is the desired bit length of the Rsa key, `n_bits_mod` must be at least 1024 bits.
     ///
     /// `pub_exp` takes in an `Option<&[u8]>` that is the public exponent. If `None` is provided, the default `2^16 +1` will be used.
-    ///  
+    ///
     /// `rsa_key_usage` takes in a [`RsaKeyUsage`] and will indicate if this key will be used for [`RsaKeyUsage::Sign`], or [`RsaKeyUsage::Encrypt`], or [`RsaKeyUsage::SignAndEncrypt`]
     pub fn generate_key_pair(
         n_bits_mod: u32,
@@ -524,6 +524,23 @@ mod test {
         let key_pair = result.unwrap();
         assert_eq!(key_pair.get_rsa_key_usage(), RsaKeyUsage::Sign);
         assert_eq!(key_pair.has_private_key(), true);
+    }
+
+    #[test]
+    fn test_generate_custom_exponent() {
+        let pub_exp: u64 = 257;
+
+        let result = RsaKey::generate_key_pair(2048, Some(&pub_exp.to_be_bytes()), RsaKeyUsage::Sign);
+        assert!(result.is_ok());
+
+        let key_pair = result.unwrap();
+        let key_pair_exported = key_pair.export_key_pair_blob().unwrap();
+
+        let pub_exp_exported = key_pair_exported.pub_exp.iter().rev()
+            .enumerate()
+            .fold(0, |v: u64, (offset, byte)| v | ((*byte as u64) << 8 * offset));
+
+        assert_eq!(pub_exp_exported, pub_exp);
     }
 
     #[test]


### PR DESCRIPTION
This commit fixes two issues
- current implementation of rsa::generate_key_pair may pass dangling pointer to SymCrypt if user provides exponent
- current implementation of rsa::set_key_pair passes dangling pointers to primes and primes length to SymCrypt