### PR TITLE
Add cargo clippy and cargo fmt to github actions

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,26 @@
+name: Cargo Clippy Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always        
+
+jobs:
+  clippy:
+    name: Clippy Check
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain 
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,13 +6,17 @@ on:
   pull_request:
 
 env:
-  CARGO_TERM_COLOR: always        
+  CARGO_TERM_COLOR: always
 
 jobs:
   clippy:
     name: Clippy Check
-    runs-on: ubuntu-latest
-    
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest] # Run on Linux and Windows
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  SYMCRYPT_LIB_PATH: "/dev/null" # Dummy value to bypass the env variable check on Windows
+
 
 jobs:
   clippy:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,26 @@
+name: Cargo Fmt Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always        
+
+jobs:
+  format:
+    name: Format Check
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/rust-symcrypt/src/cipher/cbc.rs
+++ b/rust-symcrypt/src/cipher/cbc.rs
@@ -260,7 +260,7 @@ pub mod test {
         let expected_ciphertext = hex::decode(ciphertext_hex).unwrap();
 
         let aes_cbc = AesExpandedKey::new(&key).unwrap();
-        let mut chaining_value = iv.clone();
+        let mut chaining_value = iv;
 
         // Single encryption
         let mut single_encrypted = vec![0u8; plaintext.len()];
@@ -269,7 +269,7 @@ pub mod test {
             .unwrap();
         assert_eq!(single_encrypted, expected_ciphertext);
 
-        chaining_value = iv.clone();
+        chaining_value = iv;
         let mut piecewise_encrypted = vec![0u8; plaintext.len()];
         let mid = plaintext.len() / 2;
 
@@ -308,7 +308,7 @@ pub mod test {
         let ciphertext = hex::decode(ciphertext_hex).unwrap();
 
         let aes_cbc = AesExpandedKey::new(&key).unwrap();
-        let mut chaining_value = iv.clone();
+        let mut chaining_value = iv;
 
         // Single decryption
         let mut single_decrypted = vec![0u8; ciphertext.len()];
@@ -317,7 +317,7 @@ pub mod test {
             .unwrap();
         assert_eq!(single_decrypted, expected_plaintext);
 
-        chaining_value = iv.clone();
+        chaining_value = iv;
         let mut block_by_block_decrypted = vec![0u8; ciphertext.len()];
         let block_size = AES_BLOCK_SIZE as usize;
 
@@ -350,7 +350,7 @@ pub mod test {
         let ciphertext = hex::decode(ciphertext_hex).unwrap();
 
         let aes_cbc = AesExpandedKey::new(&key).unwrap();
-        let mut chaining_value = iv.clone();
+        let mut chaining_value = iv;
 
         // Single decryption
         let mut single_decrypted = vec![0u8; ciphertext.len()];
@@ -359,7 +359,7 @@ pub mod test {
             .unwrap();
         assert_eq!(single_decrypted, expected_plaintext);
 
-        chaining_value = iv.clone();
+        chaining_value = iv;
         let mut piecewise_decrypted = vec![0u8; ciphertext.len()];
         let mid = ciphertext.len() / 2;
 
@@ -416,14 +416,14 @@ pub mod test {
         let mut buffer = plaintext.clone();
 
         // Encryption in-place
-        let mut chaining_value = iv.clone();
+        let mut chaining_value = iv;
         aes_cbc
             .aes_cbc_encrypt_in_place(&mut chaining_value, &mut buffer)
             .unwrap();
         assert_eq!(buffer, expected_ciphertext);
 
         // Decryption in-place
-        chaining_value = iv.clone();
+        chaining_value = iv;
         aes_cbc
             .aes_cbc_decrypt_in_place(&mut chaining_value, &mut buffer)
             .unwrap();
@@ -484,7 +484,6 @@ pub mod test {
         let mut handles = vec![];
         for i in 0..2 {
             let aes_cbc = Arc::clone(&aes_cbc);
-            let iv = iv.clone();
             let plaintext = plaintext.clone();
             let expected_ciphertext = expected_ciphertext.clone();
 

--- a/rust-symcrypt/src/ecc/ecdh.rs
+++ b/rust-symcrypt/src/ecc/ecdh.rs
@@ -23,9 +23,9 @@
 //! // Calculates secret agreements between private/public keys of two EcKey structs. The result
 //! // from each secret agreement should be the same.
 //! let ecdh_1_public =
-//! EcKey::set_public_key(CurveType::NistP256, &public_bytes_1.as_slice(), EcKeyUsage::EcDh).unwrap();
+//! EcKey::set_public_key(CurveType::NistP256, public_bytes_1.as_slice(), EcKeyUsage::EcDh).unwrap();
 //! let ecdh_2_public =
-//! EcKey::set_public_key(CurveType::NistP256, &public_bytes_2.as_slice(), EcKeyUsage::EcDh).unwrap();
+//! EcKey::set_public_key(CurveType::NistP256, public_bytes_2.as_slice(), EcKeyUsage::EcDh).unwrap();
 //!
 //! let secret_agreement_1 = key_1.ecdh_secret_agreement(ecdh_2_public).unwrap();
 //! let secret_agreement_2 = key_2.ecdh_secret_agreement(ecdh_1_public).unwrap();
@@ -84,13 +84,13 @@ mod test {
 
         let ecdh_1_public = EcKey::set_public_key(
             CurveType::NistP256,
-            &public_bytes_1.as_slice(),
+            public_bytes_1.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
         let ecdh_2_public = EcKey::set_public_key(
             CurveType::NistP256,
-            &public_bytes_2.as_slice(),
+            public_bytes_2.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
@@ -113,14 +113,14 @@ mod test {
 
         let ecdh_1_public = EcKey::set_public_key(
             CurveType::NistP384,
-            &public_bytes_1.as_slice(),
+            public_bytes_1.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
 
         let ecdh_2_public = EcKey::set_public_key(
             CurveType::NistP384,
-            &public_bytes_2.as_slice(),
+            public_bytes_2.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
@@ -143,14 +143,14 @@ mod test {
 
         let ecdh_1_public = EcKey::set_public_key(
             CurveType::NistP521,
-            &public_bytes_1.as_slice(),
+            public_bytes_1.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
 
         let ecdh_2_public = EcKey::set_public_key(
             CurveType::NistP521,
-            &public_bytes_2.as_slice(),
+            public_bytes_2.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
@@ -173,14 +173,14 @@ mod test {
 
         let ecdh_1_public = EcKey::set_public_key(
             CurveType::Curve25519,
-            &public_bytes_1.as_slice(),
+            public_bytes_1.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
 
         let ecdh_2_public = EcKey::set_public_key(
             CurveType::Curve25519,
-            &public_bytes_2.as_slice(),
+            public_bytes_2.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
@@ -203,14 +203,14 @@ mod test {
 
         let _ecdh_1_public = EcKey::set_public_key(
             CurveType::Curve25519,
-            &public_bytes_1.as_slice(),
+            public_bytes_1.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
 
         let ecdh_2_public = EcKey::set_public_key(
             CurveType::Curve25519,
-            &public_bytes_2.as_slice(),
+            public_bytes_2.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap_err();
@@ -230,14 +230,14 @@ mod test {
 
         let _ecdh_1_public = EcKey::set_public_key(
             CurveType::Curve25519,
-            &public_bytes_1.as_slice(),
+            public_bytes_1.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
 
         let ecdh_2_public = EcKey::set_public_key(
             CurveType::Curve25519,
-            &public_bytes_2.as_slice(),
+            public_bytes_2.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
@@ -255,7 +255,7 @@ mod test {
         let dummy_public_key_bytes = dummy_eckey.export_public_key().unwrap();
         let ecdh_1_no_private_key = EcKey::set_public_key(
             CurveType::NistP256,
-            &dummy_public_key_bytes.as_slice(),
+            dummy_public_key_bytes.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();
@@ -265,7 +265,7 @@ mod test {
         let public_bytes_2 = ecdh_2_private.export_public_key().unwrap();
         let ecdh_2_public = EcKey::set_public_key(
             CurveType::NistP256,
-            &public_bytes_2.as_slice(),
+            public_bytes_2.as_slice(),
             EcKeyUsage::EcDh,
         )
         .unwrap();

--- a/rust-symcrypt/src/ecc/mod.rs
+++ b/rust-symcrypt/src/ecc/mod.rs
@@ -508,7 +508,7 @@ mod test {
     fn test_eckey_generate_key_pair() {
         let key = EcKey::generate_key_pair(CurveType::NistP256, EcKeyUsage::EcDsa).unwrap();
         assert_eq!(key.get_curve_type(), CurveType::NistP256);
-        assert_eq!(key.has_private_key(), true);
+        assert!(key.has_private_key());
     }
 
     #[test]
@@ -517,8 +517,8 @@ mod test {
         let key2 = EcKey::generate_key_pair(CurveType::NistP256, EcKeyUsage::EcDsa).unwrap();
         assert_eq!(key.get_curve_type(), CurveType::NistP256);
         assert_eq!(key2.get_curve_type(), CurveType::NistP256);
-        assert_eq!(key.has_private_key(), true);
-        assert_eq!(key2.has_private_key(), true);
+        assert!(key.has_private_key());
+        assert!(key2.has_private_key());
     }
 
     #[test]
@@ -536,7 +536,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(key.get_curve_type(), CurveType::NistP256);
-        assert_eq!(key.has_private_key(), true);
+        assert!(key.has_private_key());
 
         let key2 = EcKey::set_key_pair(CurveType::NistP256, &private_key, None, EcKeyUsage::EcDsa)
             .unwrap();
@@ -611,8 +611,8 @@ mod test {
             EcKey::set_public_key(CurveType::NistP256, &public_key, EcKeyUsage::EcDsa).unwrap();
         assert_eq!(key.get_curve_type(), CurveType::NistP256);
         assert_eq!(key2.get_curve_type(), CurveType::NistP256);
-        assert_eq!(key.has_private_key(), true);
-        assert_eq!(key2.has_private_key(), false);
+        assert!(key.has_private_key());
+        assert!(!key2.has_private_key()); // False assertion
 
         // ensure both have the same public key
         let public_key2 = key2.export_public_key().unwrap();
@@ -627,8 +627,8 @@ mod test {
             .unwrap();
         assert_eq!(key.get_curve_type(), CurveType::NistP256);
         assert_eq!(key2.get_curve_type(), CurveType::NistP256);
-        assert_eq!(key.has_private_key(), true);
-        assert_eq!(key2.has_private_key(), true);
+        assert!(key.has_private_key());
+        assert!(key2.has_private_key());
     }
 
     #[test]
@@ -646,8 +646,8 @@ mod test {
 
         assert_eq!(key.get_curve_type(), CurveType::NistP521);
         assert_eq!(key2.get_curve_type(), CurveType::NistP521);
-        assert_eq!(key.has_private_key(), true);
-        assert_eq!(key2.has_private_key(), true);
+        assert!(key.has_private_key());
+        assert!(key2.has_private_key());
     }
 
     #[test]
@@ -693,7 +693,7 @@ mod test {
         let key =
             EcKey::set_public_key(CurveType::NistP256, &public_key, EcKeyUsage::EcDsa).unwrap();
         assert_eq!(key.get_curve_type(), CurveType::NistP256);
-        assert_eq!(key.has_private_key(), false);
+        assert!(!key.has_private_key()); // False assertion
         assert_eq!(key.inner_key(), key.inner_key());
     }
 

--- a/rust-symcrypt/src/gcm.rs
+++ b/rust-symcrypt/src/gcm.rs
@@ -361,7 +361,7 @@ mod test {
 
         let gcm_state = GcmExpandedKey::new(&p_key, cipher).unwrap();
         gcm_state
-            .decrypt_in_place(&nonce_array, &auth_data, &mut buffer, &mut tag)
+            .decrypt_in_place(&nonce_array, &auth_data, &mut buffer, &tag)
             .unwrap();
         assert_eq!(hex::encode(buffer), expected_result);
     }
@@ -381,7 +381,7 @@ mod test {
         let cipher = BlockCipherType::AesBlock;
 
         let gcm_state = GcmExpandedKey::new(&p_key, cipher).unwrap();
-        let result = gcm_state.decrypt_in_place(&nonce_array, &auth_data, &mut buffer, &mut tag);
+        let result = gcm_state.decrypt_in_place(&nonce_array, &auth_data, &mut buffer, &tag);
 
         match result {
             Ok(_) => {

--- a/rust-symcrypt/src/hash.rs
+++ b/rust-symcrypt/src/hash.rs
@@ -1226,7 +1226,7 @@ mod test {
     where
         H::Result: AsRef<[u8]>,
     {
-        hash_state.append(&data);
+        hash_state.append(data);
         let mut new_hash_state = hash_state.clone();
 
         let result = new_hash_state.result();
@@ -1241,8 +1241,8 @@ mod test {
     ) where
         H::Result: AsRef<[u8]>,
     {
-        hash_state.append(&data_1);
-        hash_state.append(&data_2);
+        hash_state.append(data_1);
+        hash_state.append(data_2);
 
         let result = hash_state.result();
         assert_eq!(

--- a/rust-symcrypt/src/hmac.rs
+++ b/rust-symcrypt/src/hmac.rs
@@ -223,7 +223,6 @@ pub struct HmacMd5State {
 }
 
 #[cfg(feature = "md5")]
-
 struct HmacMd5Inner {
     // inner represents the actual HMAC state from SymCrypt.
     inner: symcrypt_sys::SYMCRYPT_HMAC_MD5_STATE,
@@ -1297,7 +1296,7 @@ mod test {
     where
         H::Result: AsRef<[u8]>,
     {
-        hmac_state.append(&data);
+        hmac_state.append(data);
         let new_hmac_state = hmac_state.clone();
 
         let result = new_hmac_state.result();
@@ -1312,8 +1311,8 @@ mod test {
     ) where
         H::Result: AsRef<[u8]>,
     {
-        hmac_state.append(&data_1);
-        hmac_state.append(&data_2);
+        hmac_state.append(data_1);
+        hmac_state.append(data_2);
 
         let result = hmac_state.result();
         assert_eq!(hex::encode(result), expected);

--- a/rust-symcrypt/src/rsa/mod.rs
+++ b/rust-symcrypt/src/rsa/mod.rs
@@ -195,7 +195,7 @@ impl RsaKey {
         match result {
             symcrypt_sys::SYMCRYPT_ERROR_SYMCRYPT_NO_ERROR => Ok(RsaKey {
                 inner: rsa_key,
-                rsa_key_usage: rsa_key_usage,
+                rsa_key_usage,
                 has_private_key: true,
             }),
             err => Err(err.into()),
@@ -529,7 +529,7 @@ mod test {
         assert!(result.is_ok());
         let key_pair = result.unwrap();
         assert_eq!(key_pair.get_rsa_key_usage(), RsaKeyUsage::Sign);
-        assert_eq!(key_pair.has_private_key(), true);
+        assert!(key_pair.has_private_key());
     }
 
     #[test]
@@ -549,7 +549,7 @@ mod test {
             .rev()
             .enumerate()
             .fold(0, |v, (byte_offset, byte)| {
-                v | (*byte as u64) << 8 * byte_offset
+                v | (*byte as u64) << (8 * byte_offset)
             });
 
         assert_eq!(pub_exp_exported, pub_exp);
@@ -561,7 +561,7 @@ mod test {
         assert!(result.is_ok());
         let key_pair = result.unwrap();
         assert_eq!(key_pair.get_rsa_key_usage(), RsaKeyUsage::Sign);
-        assert_eq!(key_pair.has_private_key(), true);
+        assert!(key_pair.has_private_key());
 
         let blob = key_pair.export_key_pair_blob().unwrap();
         let new_key_pair = RsaKey::set_key_pair(
@@ -656,7 +656,7 @@ mod test {
         assert_eq!(key_pair.get_size_of_primes(), (128, 128));
         assert_eq!(key_pair.get_size_of_modulus(), 256);
         assert_eq!(key_pair.get_size_of_public_exponent(), 3);
-        assert_eq!(key_pair.has_private_key(), true);
+        assert!(key_pair.has_private_key());
         let key_blob = key_pair.export_key_pair_blob().unwrap();
         assert_eq!(key_blob.modulus, modulus.to_vec());
         assert_eq!(key_blob.p, p);
@@ -687,7 +687,7 @@ mod test {
         assert!(result.is_ok());
         let pub_key = result.unwrap();
 
-        assert_eq!(pub_key.has_private_key(), false);
+        assert!(!pub_key.has_private_key()); // False assertion
         assert_eq!(pub_key.get_rsa_key_usage(), RsaKeyUsage::Encrypt);
         assert_eq!(pub_key.get_size_of_modulus(), 256);
         assert_eq!(pub_key.get_size_of_public_exponent(), 3);

--- a/rust-symcrypt/src/rsa/pkcs1.rs
+++ b/rust-symcrypt/src/rsa/pkcs1.rs
@@ -261,7 +261,7 @@ mod tests {
         let res =
             key_pair.pkcs1_decrypt(&encrypted_message, &mut plaintext_buffer, &mut result_size);
         assert_eq!(res, SymCryptError::NoError);
-        plaintext_buffer.truncate(result_size as usize);
+        plaintext_buffer.truncate(result_size);
         assert_eq!(plaintext_buffer, message);
     }
 
@@ -278,9 +278,9 @@ mod tests {
         let res =
             key_pair.pkcs1_decrypt(&encrypted_message, &mut plaintext_buffer, &mut result_size);
         assert_eq!(res, SymCryptError::NoError);
-        assert_eq!(result_size, message.len() as usize);
+        assert_eq!(result_size, message.len());
         assert_eq!(plaintext_buffer.len(), 100);
-        plaintext_buffer.truncate(result_size as usize);
+        plaintext_buffer.truncate(result_size);
         assert_eq!(plaintext_buffer, message);
     }
 
@@ -297,7 +297,7 @@ mod tests {
         let res =
             key_pair.pkcs1_decrypt(&encrypted_message, &mut plaintext_buffer, &mut result_size);
         assert_eq!(res, SymCryptError::BufferTooSmall);
-        plaintext_buffer.truncate(result_size as usize);
+        plaintext_buffer.truncate(result_size);
         assert_ne!(plaintext_buffer, message);
     }
 
@@ -321,7 +321,7 @@ mod tests {
         let res =
             key_pair.pkcs1_decrypt(&encrypted_message, &mut plaintext_buffer, &mut result_size);
         assert_eq!(res, SymCryptError::NoError);
-        plaintext_buffer.truncate(result_size as usize);
+        plaintext_buffer.truncate(result_size);
         assert_eq!(plaintext_buffer, message);
     }
 


### PR DESCRIPTION
Changes:
- Adding github actions for cargo clippy and cargo fmt,
- Adding changes to address clippy and fmt.