### PR TITLE
suppress C5287

### DIFF
--- a/symcrypt-sys/build/static_link.rs
+++ b/symcrypt-sys/build/static_link.rs
@@ -89,6 +89,7 @@ impl SymCryptOptions {
                     .flag("/WX") // Treat warnings as errors
                     .flag("/guard:cf") // Control Flow Guard
                     .flag("/wd5105") // Disable warning caused by Windows SDK headers
+                    .flag("/wd5287") // Disable warning C5287: operands are different enum types '_SYMCRYPT_INTERNAL_ECURVE_TYPE' and '_SYMCRYPT_ECURVE_TYPE'; use an explicit cast to silence this warning
                     .flag("/EHsc"); // Exception handling
                                     // .flag("/dynamicbase"); // Enabling ASLR produces lots of warnings
 


### PR DESCRIPTION
### Description of Changes:

Recent update of MSVC has broken static build by adding a new warning: 

> symcrypt_internal.h(2912): warning C5287: operands are different enum types '_SYMCRYPT_INTERNAL_ECURVE_TYPE' and '_SYMCRYPT_ECURVE_TYPE'; use an explicit cast to silence this warning


### Breaking Changes if any:




### ✅ Admin Checklist
- [ ] Review the PR description and ensure all necessary details are included.
- [ ] Update/add unit tests for changed code.
- [ ] Update/add documentation for new or changed APIs.
- [ ] Run `cargo test --all-features` on `Windows` and `WSL`.

Check the Developer Guidelines in [DEVELOPER.md](./DEVELOPER.md) for more info.