### PR TITLE
REPRO for GH actions bug.

### DIFF
--- a/.github/workflows/check_system_symcrypt.yml
+++ b/.github/workflows/check_system_symcrypt.yml
@@ -2,7 +2,6 @@ name: Check System SymCrypt
 
 on:
   push:
-    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check_system_symcrypt.yml
+++ b/.github/workflows/check_system_symcrypt.yml
@@ -1,0 +1,55 @@
+name: Check System SymCrypt
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        os: [windows-latest, windows-2022, windows-2025]
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}
+    steps:
+    - name: OS info
+      shell: pwsh
+      run: |
+          [System.Environment]::OSVersion | Format-List
+          (Get-CimInstance Win32_OperatingSystem).Caption
+
+    - name: Search for symcrypt DLLs
+      shell: pwsh
+      run: |
+          Write-Output "=== Checking well-known locations ==="
+          $paths = @(
+            "C:\Windows\System32\symcrypt.dll",
+            "C:\Windows\System32\symcryptk.dll",
+            "C:\Windows\SysWOW64\symcrypt.dll"
+          )
+          foreach ($p in $paths) {
+            if (Test-Path $p) {
+              $item = Get-Item $p
+              $hash = (Get-FileHash $p -Algorithm SHA256).Hash
+              Write-Output "FOUND: $p"
+              Write-Output "  Size: $($item.Length)"
+              Write-Output "  FileVersion: $($item.VersionInfo.FileVersion)"
+              Write-Output "  ProductVersion: $($item.VersionInfo.ProductVersion)"
+              Write-Output "  SHA256: $hash"
+            } else {
+              Write-Output "NOT FOUND: $p"
+            }
+          }
+
+          Write-Output ""
+          Write-Output "=== Full system search for symcrypt*.dll ==="
+          Get-ChildItem -Path C:\Windows -Filter "symcrypt*.dll" -Recurse -ErrorAction SilentlyContinue |
+            ForEach-Object {
+              [PSCustomObject]@{
+                Path = $_.FullName
+                Size = $_.Length
+                FileVersion = $_.VersionInfo.FileVersion
+                SHA256 = (Get-FileHash $_.FullName -Algorithm SHA256).Hash
+              }
+            } | Format-Table -AutoSize -Wrap


### PR DESCRIPTION
All three GitHub Actions Windows runner images (windows-2022, windows-2025, windows-latest) ship symcrypt.dll v103.5.1 in C:\Windows\System32.

### Description of Changes:



### Breaking Changes if any:




### ✅ Admin Checklist
- [ ] Review the PR description and ensure all necessary details are included.
- [ ] Update/add unit tests for changed code.
- [ ] Update/add documentation for new or changed APIs.
- [ ] Run `cargo test --all-features` on `Windows` and `WSL`.

Check the Developer Guidelines in [DEVELOPER.md](./DEVELOPER.md) for more info.