### PR TITLE
Update build.rs to support OpenVMM use cases

### DIFF
--- a/rust-symcrypt/INSTALL.md
+++ b/rust-symcrypt/INSTALL.md
@@ -1,10 +1,12 @@
 # Detailed Build and Install
 
-This page provides more detailed installation instructions for dynamic linking on Windows and Linux.
+This page provides more detailed installation instructions for linking against `SymCrypt` on Windows and Linux.
 
-The `symcrypt` crate is a wrapper on top of the `SymCrypt` library, and requires access to the `SymCrypt` library during the build and execution stage for dynamic linking. For ease of use, the recommended way to configure your `SymCrypt` library dependancy is to obtain the required binaries from the official [SymCrypt Repo](https://github.com/microsoft/SymCrypt/releases/tag/v103.11.0).
+The `symcrypt` crate is a wrapper on top of the `SymCrypt` library, and requires access to the `SymCrypt` library during the build and execution stage. For ease of use, the recommended way to configure your `SymCrypt` library dependancy is to obtain the required binaries from the official [SymCrypt Repo](https://github.com/microsoft/SymCrypt/releases/tag/v103.11.0).
 
 However, If you wish to build your own version of the underlying `SymCrypt` library please follow the [Build Instructions](https://github.com/microsoft/SymCrypt/blob/main/BUILD.md) that are provided by SymCrypt to install SymCrypt for your target architecture.
+
+By default, the crate links against SymCrypt dynamically. See [Static Linking](#static-linking) below for the experimental static-link option.
 
 ### Windows Install 
 
@@ -41,4 +43,28 @@ After installing and unzipping SymCrypt on a Linux distro, the required `libsymc
 
 The `symcrypt` crate needs to be able to link with these libs during build/run time. In order to mimic the installation path for other libraries, you must place the `libsymcrypt.so*` files into linker load path. The way that this is set will vary between distros. On most distros it set via the environment variable `$LD_LIBRARY_PATH`.
 
+Alternatively, you can point the build at an arbitrary directory by setting `SYMCRYPT_LIB_PATH` to the folder containing `libsymcrypt.so*`. This adds that folder to the linker search path at build time but does not affect runtime library resolution — you still need the loader to find the `.so` at run time (e.g. via `LD_LIBRARY_PATH`, `rpath`, or `ldconfig`).
+
 **Note:** While the `symcrypt` crate has only been tested on `Ubuntu`, working with other distros should be similar. The goal is to place the `libsymcrypt.so*` files in a location where the your Linux distro can find the required libs at build/run time. The path may be different depending on your flavour of Linux, and architecture.
+
+---
+
+## Target-Specific Environment Variables
+
+All `SYMCRYPT_*` environment variables consumed by the build script (`SYMCRYPT_LIB_PATH`, `SYMCRYPT_STATIC`) also accept a target-prefixed form, which takes precedence when set. The prefix is the current Rust target triple, uppercased with `-` replaced by `_`.
+
+Examples:
+- `X86_64_UNKNOWN_LINUX_GNU_SYMCRYPT_LIB_PATH`
+- `AARCH64_UNKNOWN_LINUX_GNU_SYMCRYPT_LIB_PATH`
+- `X86_64_PC_WINDOWS_MSVC_SYMCRYPT_LIB_PATH`
+
+This is useful when cross-compiling or when a single host needs different values for different targets.
+
+---
+
+## Static Linking
+
+> **Experimental.** Static linking is a work-in-progress and not recommended for production use. The interface may change.
+
+Static linking can be enabled by setting the environment veriable `SYMCRYPT_STATIC` to any non-zero value (e.g. `1`). When enabled, the build script will attempt to statically link SymCrypt into the final binary,   instead of creating a dynamic link directive. Set `SYMCRYPT_LIB_PATH` to the directory containing the static `symcrypt` library. As SymCrypt's build system does not output a single static libsymcrypt library by default, acquiring such a file is left as an exercise to the reader.
+

--- a/rust-symcrypt/INSTALL.md
+++ b/rust-symcrypt/INSTALL.md
@@ -66,5 +66,5 @@ This is useful when cross-compiling or when a single host needs different values
 
 > **Experimental.** Static linking is a work-in-progress and not recommended for production use. The interface may change.
 
-Static linking can be enabled by setting the environment veriable `SYMCRYPT_STATIC` to any non-zero value (e.g. `1`). When enabled, the build script will attempt to statically link SymCrypt into the final binary,   instead of creating a dynamic link directive. Set `SYMCRYPT_LIB_PATH` to the directory containing the static `symcrypt` library. As SymCrypt's build system does not output a single static libsymcrypt library by default, acquiring such a file is left as an exercise to the reader.
+Static linking can be enabled by setting the environment veriable `SYMCRYPT_STATIC` to any non-zero value (e.g. `1`). When enabled, the build script will attempt to statically link SymCrypt into the final binary, instead of creating a dynamic link directive. Set `SYMCRYPT_LIB_PATH` to the directory containing the static `symcrypt` library. As SymCrypt's build system does not output a single static libsymcrypt library by default, acquiring such an object is left as an exercise to the reader.
 

--- a/rust-symcrypt/INSTALL.md
+++ b/rust-symcrypt/INSTALL.md
@@ -67,4 +67,3 @@ This is useful when cross-compiling or when a single host needs different values
 > **Experimental.** Static linking is a work-in-progress and not recommended for production use. The interface may change.
 
 Static linking can be enabled by setting the environment veriable `SYMCRYPT_STATIC` to any non-zero value (e.g. `1`). When enabled, the build script will attempt to statically link SymCrypt into the final binary, instead of creating a dynamic link directive. Set `SYMCRYPT_LIB_PATH` to the directory containing the static `symcrypt` library. As SymCrypt's build system does not output a single static libsymcrypt library by default, acquiring such an object is left as an exercise to the reader.
-

--- a/rust-symcrypt/README.md
+++ b/rust-symcrypt/README.md
@@ -64,7 +64,7 @@ To enable either `Md5` or `Sha1`, or `Pkcs1 Encrypt/Decrypt` pass the `md5` or `
 
 ## Quick Start Guide
 
-The `symcrypt` crate uses dynamic linking. This requires the `SymCrypt` library to be available on your system at build and runtime.
+The `symcrypt` crate links against the `SymCrypt` library dynamically by default. This requires the `SymCrypt` library to be available on your system at build and runtime. Experimental static linking is also available, see [`INSTALL.md`](./INSTALL.md#static-linking) for details.
 
 ### Windows:
 Download the latest `symcrypt.dll` and `symcrypt.lib` for your corresponding CPU architecture from the [SymCrypt Releases Page](https://github.com/microsoft/SymCrypt/releases) and place them somewhere accessible on your machine.

--- a/symcrypt-sys/build.rs
+++ b/symcrypt-sys/build.rs
@@ -1,35 +1,49 @@
-#[cfg(target_os = "windows")]
-use std::env;
+fn env_var_for_target(name: &str) -> Option<String> {
+    let prefix = std::env::var("TARGET")
+        .unwrap()
+        .to_uppercase()
+        .replace('-', "_");
+    let prefixed = format!("{prefix}_{name}");
 
-fn main() {
-    #[cfg(target_os = "windows")]
-    {
-        // Look for the .lib file during link time. We are searching the PATH for symcrypt.dll
-        let lib_path = env::var("SYMCRYPT_LIB_PATH")
-            .unwrap_or_else(|_| panic!("SYMCRYPT_LIB_PATH environment variable not set, for more information please see: https://github.com/microsoft/rust-symcrypt/tree/main/rust-symcrypt#quick-start-guide"));
-        println!("cargo:rustc-link-search=native={}", lib_path);
-
-        println!("cargo:rustc-link-lib=dylib=symcrypt");
-
-        // During run time, the OS will handle finding the symcrypt.dll file. The places Windows will look will be:
-        // 1. The folder from which the application loaded.
-        // 2. The system folder. Use the GetSystemDirectory function to retrieve the path of this folder.
-        // 3. The Windows folder. Use the GetWindowsDirectory function to get the path of this folder.
-        // 4. The current folder.
-        // 5. The directories that are listed in the PATH environment variable.
-
-        // For more info please see: https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order
+    fn env_inner(name: &str) -> Option<String> {
+        let var = std::env::var_os(name);
+        let var = var.map(|x| x.to_string_lossy().into());
+        println!("cargo:rerun-if-env-changed={name}");
+        // Debug prints
+        match var {
+            Some(ref v) => println!("{} = {}", name, v),
+            None => println!("{name} unset"),
+        }
+        var
     }
 
-    #[cfg(target_os = "linux")]
-    {
-        println!("cargo:rustc-link-lib=dylib=symcrypt"); // the "lib" prefix for libsymcrypt is implied on Linux
+    env_inner(&prefixed).or_else(|| env_inner(name))
+}
 
-        // If you are using Azure Linux 3, you can get the required symcrypt.so via tdnf.
-        // If you are using Ubuntu, you can get the required symcrypt.so via PMC.
-        // Please see the quick start guide for more information.
+fn main() {
+    // Optionally allow callers to override where the linker/loader looks for
+    // libsymcrypt by setting SYMCRYPT_LIB_PATH (or the target-specific
+    // variant, e.g. X86_64_UNKNOWN_LINUX_GNU_SYMCRYPT_LIB_PATH). This is
+    // useful when libsymcrypt is not installed in a default library
+    // search path, or when cross-compiling.
+    if let Some(lib_path) = env_var_for_target("SYMCRYPT_LIB_PATH") {
+        println!("cargo:rustc-link-search=native={}", lib_path);
+    } else {
+        #[cfg(windows)]
+        panic!("SYMCRYPT_LIB_PATH environment variable not set, for more information please see: https://github.com/microsoft/rust-symcrypt/tree/main/rust-symcrypt#quick-start-guide")
+    }
 
-        // If you are using a different Linux distro, you will need to configure your distro's
-        // LD linker to find the required symcrypt.so files.
+    if let Some(static_link) = env_var_for_target("SYMCRYPT_STATIC") {
+        if static_link != "0" {
+            // Order matters: generic references common/module symbols.
+            println!("cargo:rustc-link-lib=static=symcrypt_generic");
+            println!("cargo:rustc-link-lib=static=symcrypt_module_posix_common");
+            println!("cargo:rustc-link-lib=static=symcrypt_common");
+            println!("cargo:rustc-link-lib=static=symcrypt_posixusermode");
+        } else {
+            println!("cargo:rustc-link-lib=dylib=symcrypt");
+        }
+    } else {
+        println!("cargo:rustc-link-lib=dylib=symcrypt");
     }
 }

--- a/symcrypt-sys/build.rs
+++ b/symcrypt-sys/build.rs
@@ -35,11 +35,7 @@ fn main() {
 
     if let Some(static_link) = env_var_for_target("SYMCRYPT_STATIC") {
         if static_link != "0" {
-            // Order matters: generic references common/module symbols.
-            println!("cargo:rustc-link-lib=static=symcrypt_generic");
-            println!("cargo:rustc-link-lib=static=symcrypt_module_posix_common");
-            println!("cargo:rustc-link-lib=static=symcrypt_common");
-            println!("cargo:rustc-link-lib=static=symcrypt_posixusermode");
+            println!("cargo:rustc-link-lib=static=symcrypt");
         } else {
             println!("cargo:rustc-link-lib=dylib=symcrypt");
         }


### PR DESCRIPTION
### Description of Changes:
This PR adds two features to build.rs. The first is supporting per-target environment variables for configuration. This aids in cross-compilation, and is the approach used by the openssl crate. The second is a new environment variable, SYMCRYPT_STATIC, that emits a static linking directive instead of a dynamic one. It does not add any support for producing a suitable static library. Finally this PR updates the documentation to include the new support.

### Breaking Changes if any:
I believe there should be none.