### PR TITLE
fixing 32bit truncation for HKDF and sp800

### DIFF
--- a/rust-symcrypt/src/hkdf.rs
+++ b/rust-symcrypt/src/hkdf.rs
@@ -54,15 +54,15 @@ use symcrypt_sys;
 /// `info` is a `&[u8]` that represents an optional application-specific context that customizes the derived key. If you do not
 /// wish to use a salt, you can pass an empty slice.
 ///
-/// `output_key_size` is an `u64` that represents the desired length of the derived key in bytes, the `Vec<u8>` returned will be of this length.
+/// `output_key_size` is a `usize` that represents the desired length of the derived key in bytes, the `Vec<u8>` returned will be of this length.
 pub fn hkdf(
     hmac_algorithm: HmacAlgorithm,
     key_material: &[u8],
     salt: &[u8],
     info: &[u8],
-    output_key_size: u64,
+    output_key_size: usize,
 ) -> Result<Vec<u8>, SymCryptError> {
-    let mut hmac_res = vec![0u8; output_key_size as usize];
+    let mut hmac_res = vec![0u8; output_key_size];
     unsafe {
         // UNSAFE: FFI calls
         match symcrypt_sys::SymCryptHkdf(

--- a/rust-symcrypt/src/sp800_108.rs
+++ b/rust-symcrypt/src/sp800_108.rs
@@ -55,17 +55,17 @@ use symcrypt_sys;
 ///
 /// `context` is a `&[u8]` containing application-specific context bytes. You can pass an empty slice.
 ///
-/// `output_key_size` is a `u64` specifying the desired length of the derived key in bytes.
+/// `output_key_size` is a `usize` specifying the desired length of the derived key in bytes.
 /// The returned `Vec<u8>` will have exactly this length.
 pub fn sp800_108_counter_mode(
     hmac_algorithm: HmacAlgorithm,
     key_material: &[u8],
     label: &[u8],
     context: &[u8],
-    output_key_size: u64,
+    output_key_size: usize,
 ) -> Result<Vec<u8>, SymCryptError> {
     symcrypt_init();
-    let mut result = vec![0u8; output_key_size as usize];
+    let mut result = vec![0u8; output_key_size];
     unsafe {
         // UNSAFE: FFI calls
         match symcrypt_sys::SymCryptSp800_108(


### PR DESCRIPTION
### Description of Changes:
Changed sp800 and hdkf API to output `usize` rather than `u64` to not truncate on 32 bit system 


### Breaking Changes if any:
HKDF API signature changed: 
```
pub fn hkdf(
    hmac_algorithm: HmacAlgorithm,
    key_material: &[u8],
    salt: &[u8],
    info: &[u8],
    output_key_size: usize, <----- Changed from u64
) -> Result<Vec<u8>, SymCryptError> {
```

Same applies for Sp800 but the change is not in cargo yet. 

### ✅ Admin Checklist
- [x] Review the PR description and ensure all necessary details are included.
- [x] Update/add unit tests for changed code.
- [x] Update/add documentation for new or changed APIs.
- [ ] Run `cargo test --all-features` on `Windows` and `WSL`.

Check the Developer Guidelines in [DEVELOPER.md](./DEVELOPER.md) for more info.