### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -28,7 +28,7 @@ jobs:
     name: Bindgen ${{ matrix.target }}
 
     steps:
-    - uses: actions/checkout@v4 # Checks out SymCrypt based on Github submodule
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         submodules: true
 
@@ -41,7 +41,7 @@ jobs:
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
         }
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
     - name: Generate bindings
       shell: pwsh
@@ -55,7 +55,7 @@ jobs:
     - name: Check for 'publish_new_bindings' label
       id: check_label
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
       with:
         script: |
           const labels = context.payload.pull_request.labels.map(label => label.name);
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload bindings as artifact
       if: steps.check_label.outputs.result == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ env.NEW_BINDINGS_FILE_NAME }}
         path: ${{ env.NEW_BINDINGS_FILE_PATH }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -30,11 +30,11 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     
     steps:
-    - uses: actions/checkout@v4 # Checks out SymCrypt based on Github submodule
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         submodules: true
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
     # Download SymCrypt via PMC
     - name: Install SymCrypt via PMC

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -31,11 +31,11 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
 
     steps:
-    - uses: actions/checkout@v4 # Checks out SymCrypt based on Github submodule
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         submodules: true
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     
     # Install host architecture, required for cross-compilation since there is no arm64-windows-msvc runner
     - name: Install host target

--- a/.github/workflows/check-submodule.yml
+++ b/.github/workflows/check-submodule.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository with Submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust toolchain 
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/linelint.yml
+++ b/.github/workflows/linelint.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check if all files end in newline
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
     - name: Linelint
-      uses: fernandrone/linelint@0.0.6
+      uses: fernandrone/linelint@7907a5dca0c28ea7dd05c6d8d8cacded713aca11 # 0.0.6
       id: linelint


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
